### PR TITLE
filenames: fix adding files/folders X_y (Xy) then x_y on case insensitive filesystems

### DIFF
--- a/Lib/ufoLib/filenames.py
+++ b/Lib/ufoLib/filenames.py
@@ -102,6 +102,7 @@ def userNameToFileName(userName, existing=[], prefix="", suffix=""):
 	userName = ".".join(parts)
 	# test for clash
 	fullName = prefix + userName + suffix
+	existing = [name.lower() for name in existing]
 	if fullName.lower() in existing:
 		fullName = handleClash1(userName, existing, prefix, suffix)
 	# finished


### PR DESCRIPTION
See same issue in ufonormalizer https://github.com/unified-font-object/ufoNormalizer/pull/16

Currently:
```python
>>> from ufoLib.filenames import userNameToFileName
>>> newNames = []
>>> newNames.append(userNameToFileName(u"Xy"))
>>> newNames.append(userNameToFileName(u"x_y", newNames))
>>> print(newNames)
[u'X_y', u'x_y']
```

After fix:
```python
>>> from ufoLib.filenames import userNameToFileName
>>> newNames = []
>>> newNames.append(userNameToFileName(u"Xy"))
>>> newNames.append(userNameToFileName(u"x_y", newNames))
>>> print(newNames)
[u'X_y', u'x_y000000000000001']
```