### PR TITLE
README: link badges with Travis-CI and AppVeyor project pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-![Build Status](https://api.travis-ci.org/unified-font-object/ufoLib.svg)
-![AppVeyor Status](https://ci.appveyor.com/api/projects/status/github/unified-font-object/ufoLib?svg=true)
+[![Build Status](https://api.travis-ci.org/unified-font-object/ufoLib.svg)](https://travis-ci.org/unified-font-object/ufoLib)
+[![AppVeyor Status](https://ci.appveyor.com/api/projects/status/github/unified-font-object/ufoLib?svg=true)](https://ci.appveyor.com/project/adrientetar/ufolib)
 ![Python Versions](https://img.shields.io/badge/python-2.7%2C%203.4%2C%203.5-blue.svg)
 
 ufoLib


### PR DESCRIPTION
Clicking on the badges should open the CI project pages.

BTW the [AppVeyor project](https://ci.appveyor.com/project/unified-font-object/ufoLib) doesn’t seem to be enabled.