### PR TITLE
[ufo4] Fix _getGlyphSetFormatVersion3()

### DIFF
--- a/Lib/ufoLib/__init__.py
+++ b/Lib/ufoLib/__init__.py
@@ -880,7 +880,7 @@ class UFOWriter(FileSystem):
 		# store the mapping
 		self.layerContents[layerName] = directory
 		# load the glyph set
-		return GlyphSet(path, fileSystem=self, glyphNameToFileNameFunc=glyphNameToFileNameFunc, ufoFormatVersion=3)
+		return GlyphSet(directory, fileSystem=self, glyphNameToFileNameFunc=glyphNameToFileNameFunc, ufoFormatVersion=3)
 
 	def renameGlyphSet(self, layerName, newLayerName, defaultLayer=False):
 		"""


### PR DESCRIPTION
```python
Python 2.7.11 (default, Dec 16 2015, 11:56:37)
[GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from ufoLib import UFOWriter
>>> writer = UFOWriter('foo.ufo', structure='zip')
>>> writer.getGlyphSet()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/mnakamura/.ghq/github.com/mashabow/ufoLib/Lib/ufoLib/__init__.py", line 842, in getGlyphSet
    return self._getGlyphSetFormatVersion3(layerName=layerName, defaultLayer=defaultLayer, glyphNameToFileNameFunc=glyphNameToFileNameFunc)
  File "/Users/mnakamura/.ghq/github.com/mashabow/ufoLib/Lib/ufoLib/__init__.py", line 883, in _getGlyphSetFormatVersion3
    return GlyphSet(path, fileSystem=self, glyphNameToFileNameFunc=glyphNameToFileNameFunc, ufoFormatVersion=3)
NameError: global name 'path' is not defined
```
