### PR TITLE
glifLib: don't write empty 'lib' element in layerinfo.plist

### DIFF
--- a/Lib/ufoLib/glifLib.py
+++ b/Lib/ufoLib/glifLib.py
@@ -203,7 +203,7 @@ class GlyphSet(object):
 					value = getattr(info, attr)
 				except AttributeError:
 					raise GlifLibError("The supplied info object does not support getting a necessary attribute (%s)." % attr)
-				if value is None:
+				if value is None or (attr == 'lib' and not value):
 					continue
 				infoData[attr] = value
 		# validate


### PR DESCRIPTION
the `layerinfo.plist` is an optional file. there's no reason why ufoLib has to write it all the time even when there's no `color` nor `lib` elements.
Currently the `lib` dict was being written all the time even if empty, and as a result a `layerinfo.plist` file is always generated, even if it does not contain any meaningful information.