### PR TITLE
Set up CI to run pytest with tox; prepare auto-deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,11 @@
 language: python
-sudo: required
+sudo: false
 python:
   - "2.7"
   - "3.4"
   - "3.5"
-before_install:
-  - git clone --depth=1 https://github.com/behdad/fonttools.git
 install:
-  - cd fonttools; python setup.py install; cd ..
-  - python setup.py install
-script:
-  - python -c "import fontTools"
-  - python setup.py test
+  - pip install --upgrade pip setuptools wheel
+  - pip install tox-travis
+script: tox
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,39 @@ install:
   - pip install --upgrade pip setuptools wheel
   - pip install tox-travis
 script: tox
-
+# after_success:
+#   - pip wheel --no-deps -w dist .
+#   - python setup.py sdist
+# before_deploy:
+#   - export ZIP=$(ls dist/ufoLib*.zip)
+#   - export WHL=$(ls dist/ufoLib*.whl)
+#
+## Replace the encrypted Github api key and PyPI password to enable automatic
+## deployment of wheel and sdist to Github Releases and PyPI on tags.
+#
+# deploy:
+#   # deploy to Github Releases on tags
+#   - provider: releases
+#     api_key:
+#       secure: H2rz0E/GjRrRmvf6EYWv7Fyu+y4qU+InGiYlQ6xoyrjmMFCTYiPNW0ysu8893JFILusfO48zzEix7HcumQXtJU16XYwqft9eiWIGzSlP1krusmpQ0yTnuy9wEQcd7fXLEQDfiVZpJxWpC1TtsuIdDqpSUFcHDg4hlvn1IIh+6HwRP6+M5Mprze087ydBCKkO4CvqR4olC7bkSPorRtqUsiUHlUxYFS+R75a8ghqVQbky7ew9/r90zljCBFwYTPEv9tQ7OxnAQiUaAYojceThsBrNP1lH83tOoqB2FkKr9I5dxi5gqNuUsJHh3QK0V59oQCxU+iVFYfrlIZHTBQ+2caxIeWm2k9RkMXXkbg1LyfpORt+5L+NcFNE4WT0DTlYrKnpW+jrak0LEWaI97+15uHahph3vOJgaZrTFvRQZUJTWCNcji2jGbZg+O3pS1Vtd1xEgJ1TcrkOYLYBMrVOywbuQL4sXofLxH3I5RwAenkgm5TwxtuiNxpUkqlEhzJ+GYwWtfb7/qtcLIK7Xn6cDdsQG6XYQMVt+HpCKgRLlrQC8si6l+jZBEtJ7o4IKeYbtybFCe5H3V0jnRFRyncPPdpBavqJ093Pr7fGLvmZuHl551WRtyPlBN4aMGsqvqUSjwr/TxsX5zZ1tQ4QTN2YTmCdeUO6P/fwTBf5p0F3QFo8=
+#     file:
+#       - "${ZIP}"
+#       - "${WHL}"
+#     skip_cleanup: true
+#     on:
+#       repo: unified-font-object/ufoLib
+#       tags: true
+#       all_branches: true
+#       python: 3.5
+#   # deploy to PyPI on tags
+#   - provider: pypi
+#     server: https://upload.pypi.org/legacy/
+#     on:
+#       repo: unified-font-object/ufoLib
+#       tags: true
+#       all_branches: true
+#       python: 3.5
+#     user: anthrotype
+#     password:
+#       secure: B6rFOTA8ol1kt210q7USDVOzLFWUyMIwdZuaUdejYmUb0CXK6W8kKj0H01yBCgjkhtew9YEQSB62jFiGUOJH9L8JjpJO2RG8cHIIblXQfQ5DXogmcEtsAFotQz0o3UO/SYJaMY917XsPCqw3MTgksd2NWwO7H3YCjaWntN4zZxyTWowGr2Vhbj9s8e+MGMtrZ3Is91AcoXNI7HPj2oVhAtPP5GGpceIP7JlOGdHGUFJKuwJLRKVjEURWXN6ZOQNoxuG6KdkpGtJYCFgRCW65e48WpQs8lts/ByyOMyRItPIPI+K/cPOaIvZ7IUhu9SueBgKcW2YVzQrPzD07N5Lhb4LaKhqgMwpy7oWntnpO0/Xes7bonAoDYKPz7O3O3zl57fy1sVhGXZZNoGUfwyFz1PPecONavRpDQYCMEOq8BcENT86mf0xbAvtmTvBgos8NknmZ35ckUkyrye8t058CwW0yhEO2Pr36XPKoEP9EAiq2YRvINPYnI1T3jTPUUwnc3IAv4zQvPUKWqs2/hEVy8FTCz/0hBgDv2cs4pRcofTzfXSczGMfyuNS3i4n3CHc4FEOYP9MuEWGDC7KF4MVNsBWbh5pkISwhIwNbW1UDept2k+Dmb9XrSoCt5aSvEPJVT3YTA4qTGSUQvhzj1SvXi3s2lh+1WbibEJqNfpdobGg=
+#     distributions: sdist bdist_wheel

--- a/Lib/ufoLib/__init__.py
+++ b/Lib/ufoLib/__init__.py
@@ -1176,10 +1176,12 @@ def makeUFOPath(path):
 	"""
 	Return a .ufo pathname.
 
-	>>> makeUFOPath("/directory/something.ext")
-	'/directory/something.ufo'
-	>>> makeUFOPath("/directory/something.another.thing.ext")
-	'/directory/something.another.thing.ufo'
+	>>> makeUFOPath("directory/something.ext") == (
+	... 	os.path.join('directory', 'something.ufo'))
+	True
+	>>> makeUFOPath("directory/something.another.thing.ext") == (
+	... 	os.path.join('directory', 'something.another.thing.ufo'))
+	True
 	"""
 	dir, name = os.path.split(path)
 	name = ".".join([".".join(name.split(".")[:-1]), "ufo"])

--- a/Lib/ufoLib/converters.py
+++ b/Lib/ufoLib/converters.py
@@ -253,15 +253,10 @@ def test():
     ... }
     >>> groups == expected
     True
-    
-    >>> kerningDict = {}
-    >>> for first, seconds in kerning.items():
-    ...     for s, value in seconds.items():
-    ...         key = (first, s)
-    ...         kerningDict[key] = value
-    >>> from validators import kerningValidator
-    >>> kerningValidator(kerningDict, groups)
-    (True, [])
+
+    >>> from .validators import kerningValidator
+    >>> kerningValidator(kerning)
+    (True, None)
 
     Mixture of known prefixes and groups without prefixes.
 

--- a/Lib/ufoLib/filenames.py
+++ b/Lib/ufoLib/filenames.py
@@ -2,6 +2,7 @@
 User name to file name conversion.
 This was taken form the UFO 3 spec.
 """
+from __future__ import unicode_literals
 from fontTools.misc.py23 import basestring, unicode
 
 
@@ -22,50 +23,50 @@ def userNameToFileName(userName, existing=[], prefix="", suffix=""):
 	existing should be a case-insensitive list
 	of all existing file names.
 
-	>>> userNameToFileName(u"a")
-	u'a'
-	>>> userNameToFileName(u"A")
-	u'A_'
-	>>> userNameToFileName(u"AE")
-	u'A_E_'
-	>>> userNameToFileName(u"Ae")
-	u'A_e'
-	>>> userNameToFileName(u"ae")
-	u'ae'
-	>>> userNameToFileName(u"aE")
-	u'aE_'
-	>>> userNameToFileName(u"a.alt")
-	u'a.alt'
-	>>> userNameToFileName(u"A.alt")
-	u'A_.alt'
-	>>> userNameToFileName(u"A.Alt")
-	u'A_.A_lt'
-	>>> userNameToFileName(u"A.aLt")
-	u'A_.aL_t'
-	>>> userNameToFileName(u"A.alT")
-	u'A_.alT_'
-	>>> userNameToFileName(u"T_H")
-	u'T__H_'
-	>>> userNameToFileName(u"T_h")
-	u'T__h'
-	>>> userNameToFileName(u"t_h")
-	u't_h'
-	>>> userNameToFileName(u"F_F_I")
-	u'F__F__I_'
-	>>> userNameToFileName(u"f_f_i")
-	u'f_f_i'
-	>>> userNameToFileName(u"Aacute_V.swash")
-	u'A_acute_V_.swash'
-	>>> userNameToFileName(u".notdef")
-	u'_notdef'
-	>>> userNameToFileName(u"con")
-	u'_con'
-	>>> userNameToFileName(u"CON")
-	u'C_O_N_'
-	>>> userNameToFileName(u"con.alt")
-	u'_con.alt'
-	>>> userNameToFileName(u"alt.con")
-	u'alt._con'
+	>>> userNameToFileName("a") == "a"
+	True
+	>>> userNameToFileName("A") == "A_"
+	True
+	>>> userNameToFileName("AE") == "A_E_"
+	True
+	>>> userNameToFileName("Ae") == "A_e"
+	True
+	>>> userNameToFileName("ae") == "ae"
+	True
+	>>> userNameToFileName("aE") == "aE_"
+	True
+	>>> userNameToFileName("a.alt") == "a.alt"
+	True
+	>>> userNameToFileName("A.alt") == "A_.alt"
+	True
+	>>> userNameToFileName("A.Alt") == "A_.A_lt"
+	True
+	>>> userNameToFileName("A.aLt") == "A_.aL_t"
+	True
+	>>> userNameToFileName(u"A.alT") == "A_.alT_"
+	True
+	>>> userNameToFileName("T_H") == "T__H_"
+	True
+	>>> userNameToFileName("T_h") == "T__h"
+	True
+	>>> userNameToFileName("t_h") == "t_h"
+	True
+	>>> userNameToFileName("F_F_I") == "F__F__I_"
+	True
+	>>> userNameToFileName("f_f_i") == "f_f_i"
+	True
+	>>> userNameToFileName("Aacute_V.swash") == "A_acute_V_.swash"
+	True
+	>>> userNameToFileName(".notdef") == "_notdef"
+	True
+	>>> userNameToFileName("con") == "_con"
+	True
+	>>> userNameToFileName("CON") == "C_O_N_"
+	True
+	>>> userNameToFileName("con.alt") == "_con.alt"
+	True
+	>>> userNameToFileName("alt.con") == "alt._con"
+	True
 	"""
 	# the incoming name must be a unicode string
 	if not isinstance(userName, unicode):
@@ -116,20 +117,23 @@ def handleClash1(userName, existing=[], prefix="", suffix=""):
 
 	>>> e = list(existing)
 	>>> handleClash1(userName="A" * 5, existing=e,
-	...		prefix=prefix, suffix=suffix)
-	'00000.AAAAA000000000000001.0000000000'
+	...		prefix=prefix, suffix=suffix) == (
+	... 	'00000.AAAAA000000000000001.0000000000')
+	True
 
 	>>> e = list(existing)
 	>>> e.append(prefix + "aaaaa" + "1".zfill(15) + suffix)
 	>>> handleClash1(userName="A" * 5, existing=e,
-	...		prefix=prefix, suffix=suffix)
-	'00000.AAAAA000000000000002.0000000000'
+	...		prefix=prefix, suffix=suffix) == (
+	... 	'00000.AAAAA000000000000002.0000000000')
+	True
 
 	>>> e = list(existing)
 	>>> e.append(prefix + "AAAAA" + "2".zfill(15) + suffix)
 	>>> handleClash1(userName="A" * 5, existing=e,
-	...		prefix=prefix, suffix=suffix)
-	'00000.AAAAA000000000000001.0000000000'
+	...		prefix=prefix, suffix=suffix) == (
+	... 	'00000.AAAAA000000000000001.0000000000')
+	True
 	"""
 	# if the prefix length + user name length + suffix length + 15 is at
 	# or past the maximum length, silce 15 characters off of the user name
@@ -168,18 +172,21 @@ def handleClash2(existing=[], prefix="", suffix=""):
 	>>> existing = [prefix + str(i) + suffix for i in range(100)]
 
 	>>> e = list(existing)
-	>>> handleClash2(existing=e, prefix=prefix, suffix=suffix)
-	'00000.100.0000000000'
+	>>> handleClash2(existing=e, prefix=prefix, suffix=suffix) == (
+	... 	'00000.100.0000000000')
+	True
 
 	>>> e = list(existing)
 	>>> e.remove(prefix + "1" + suffix)
-	>>> handleClash2(existing=e, prefix=prefix, suffix=suffix)
-	'00000.1.0000000000'
+	>>> handleClash2(existing=e, prefix=prefix, suffix=suffix) == (
+	... 	'00000.1.0000000000')
+	True
 
 	>>> e = list(existing)
 	>>> e.remove(prefix + "2" + suffix)
-	>>> handleClash2(existing=e, prefix=prefix, suffix=suffix)
-	'00000.2.0000000000'
+	>>> handleClash2(existing=e, prefix=prefix, suffix=suffix) == (
+	... 	'00000.2.0000000000')
+	True
 	"""
 	# calculate the longest possible string
 	maxLength = maxFileNameLength - len(prefix) - len(suffix)

--- a/Lib/ufoLib/glifLib.py
+++ b/Lib/ufoLib/glifLib.py
@@ -1291,7 +1291,7 @@ def _number(s):
 	1
 	>>> _number("1.0")
 	1.0
-	>>> _number("a")
+	>>> _number("a")  # doctest: +IGNORE_EXCEPTION_DETAIL
 	Traceback (most recent call last):
 	    ...
 	GlifLibError: Could not convert a to an int or float.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,9 @@
+include README.md notes.txt LICENSE.txt
+
+include Documentation/Makefile
+recursive-include Documentation *.py *.rst
+
+recursive-include Data *.plist *.glif
+recursive-include TestData *.plist *.glif *.fea *.txt
+
+include requirements.txt tox.ini

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,26 +4,38 @@ environment:
     - PYTHON: "C:\\Python27"
       PYTHON_VERSION: "2.7.x"
       PYTHON_ARCH: "32"
+      TOXENV: "py27"
+      TOXPYTHON: "C:\\Python27\\python.exe"
 
     - PYTHON: "C:\\Python34"
-      PYTHON_VERSION: "3.4.0"
+      PYTHON_VERSION: "3.4.x"
       PYTHON_ARCH: "32"
+      TOXENV: "py34"
+      TOXPYTHON: "C:\\Python34\\python.exe"
 
     - PYTHON: "C:\\Python35"
-      PYTHON_VERSION: "3.5.0"
+      PYTHON_VERSION: "3.5.x"
       PYTHON_ARCH: "32"
+      TOXENV: "py35"
+      TOXPYTHON: "C:\\Python35\\python.exe"
 
     - PYTHON: "C:\\Python27-x64"
       PYTHON_VERSION: "2.7.x"
       PYTHON_ARCH: "64"
+      TOXENV: "py27"
+      TOXPYTHON: "C:\\Python27-x64\\python.exe"
 
     - PYTHON: "C:\\Python34-x64"
       PYTHON_VERSION: "3.4.x"
       PYTHON_ARCH: "64"
+      TOXENV: "py34"
+      TOXPYTHON: "C:\\Python34-x64\\python.exe"
 
     - PYTHON: "C:\\Python35-x64"
       PYTHON_VERSION: "3.5.x"
       PYTHON_ARCH: "64"
+      TOXENV: "py35"
+      TOXPYTHON: "C:\\Python35-x64\\python.exe"
 
 init:
   - "ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH%"
@@ -43,24 +55,13 @@ install:
   # upgrade pip to avoid out-of-date warnings
   - "pip install --disable-pip-version-check --user --upgrade pip"
 
-  # install wheel to build compiled packages
-  # - "pip install --upgrade wheel"
+  # install/upgrade setuptools and wheel to build packages
+  - "pip install --upgrade setuptools wheel"
 
-  # install requirements
-  - "pip install git+https://github.com/behdad/fonttools.git"
-
-  # install
-  - "python setup.py install"
+  # install tox to run test suite in a virtual environment
+  - "pip install -U tox"
 
 build: false
 
 test_script:
-  - "python setup.py test"
-
-# after_test:
-#   # if tests are successful, create binary packages for the project
-#   - "pip wheel -w dist ."
-
-# artifacts:
-#   # archive the generated packages in the ci.appveyor.com build report
-#   - path: dist\*
+  - "tox"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+# TODO(anthrotype): replace it with 'fonttools>=3.1' once it's on PyPI
+https://github.com/behdad/fonttools/archive/7930106740f6f6f25583836c56c6cc593762e779.zip

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,20 @@
+[wheel]
+universal = 1
+
+[sdist]
+formats = zip
+
+[aliases]
+test = pytest
+
+[tool:pytest]
+minversion = 3.0.2
+testpaths =
+    Lib/ufoLib
+addopts =
+    # run py.test in verbose mode
+    -v
+    # show extra test summary info
+    -r a
+    # run doctests in all .py modules
+    --doctest-modules

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,6 @@
 #! /usr/bin/env python
-
-import os, sys
-
-try:
-	from setuptools import setup
-	extra_kwargs = {
-		"test_suite": "ufoLib.test"
-	}
-except ImportError:
-	from distutils.core import setup
-	extra_kwargs = {}
+import sys
+from setuptools import setup, find_packages
 
 try:
 	import fontTools
@@ -23,35 +14,49 @@ ufoLib reads and writes Unified Font Object (UFO) files. UFO is a file format
 that stores fonts source files.
 """
 
-setup(
-		name = "ufoLib",
-		version = "1.2",
-		description = "A low-level UFO reader and writer.",
-		author = "Just van Rossum, Tal Leming, Erik van Blokland, others",
-		author_email = "info@robofab.com",
-		maintainer = "Just van Rossum, Tal Leming, Erik van Blokland",
-		maintainer_email = "info@robofab.com",
-		url = "http://unifiedfontobject.org",
-		license = "OpenSource, BSD-style",
-		platforms = ["Any"],
-		long_description = long_description,
+needs_pytest = {'pytest', 'test'}.intersection(sys.argv)
+pytest_runner = ['pytest_runner'] if needs_pytest else []
+needs_wheel = {'bdist_wheel'}.intersection(sys.argv)
+wheel = ['wheel'] if needs_wheel else []
 
-		packages = [
-			"ufoLib",
-		],
-		package_dir = {'': 'Lib'},
-		classifiers = [
-			"Development Status :: 4 - Beta",
-			"Environment :: Console",
-			"Environment :: Other Environment",
-			"Intended Audience :: Developers",
-			"Intended Audience :: End Users/Desktop",
-			"License :: OSI Approved :: BSD License",
-			"Natural Language :: English",
-			"Operating System :: OS Independent",
-			"Programming Language :: Python",
-			"Topic :: Multimedia :: Graphics",
-			"Topic :: Multimedia :: Graphics :: Graphics Conversion",
-		],
-		**extra_kwargs
-	)
+setup_params = dict(
+	name="ufoLib",
+	version="2.0.dev1",
+	description="A low-level UFO reader and writer.",
+	author="Just van Rossum, Tal Leming, Erik van Blokland, others",
+	author_email="info@robofab.com",
+	maintainer="Just van Rossum, Tal Leming, Erik van Blokland",
+	maintainer_email="info@robofab.com",
+	url="http://unifiedfontobject.org",
+	license="OpenSource, BSD-style",
+	platforms=["Any"],
+	long_description=long_description,
+	package_dir={'': 'Lib'},
+	packages=find_packages('Lib'),
+	setup_requires=pytest_runner + wheel,
+	tests_require=[
+		'pytest>=3.0.2',
+	],
+	install_requires=[
+		# TODO(anthrotype): un-comment this once fonttools>=3.1 is on PyPI.
+		# In the meantime, pip install -r requirements.txt
+		# "fonttools>=3.1",
+	],
+	classifiers=[
+		"Development Status :: 4 - Beta",
+		"Environment :: Console",
+		"Environment :: Other Environment",
+		"Intended Audience :: Developers",
+		"Intended Audience :: End Users/Desktop",
+		"License :: OSI Approved :: BSD License",
+		"Natural Language :: English",
+		"Operating System :: OS Independent",
+		"Programming Language :: Python",
+		"Topic :: Multimedia :: Graphics",
+		"Topic :: Multimedia :: Graphics :: Graphics Conversion",
+	],
+)
+
+
+if __name__ == "__main__":
+	setup(**setup_params)

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,15 @@
+[tox]
+envlist = py27, py35
+
+[testenv]
+basepython =
+    # we use TOXPYTHON env variable to specify the location of Appveyor Python
+    py27: {env:TOXPYTHON:python2.7}
+    py34: {env:TOXPYTHON:python3.4}
+    py35: {env:TOXPYTHON:python3.5}
+deps =
+    pytest
+    -rrequirements.txt
+commands =
+    # pass to pytest any extra positional arguments after `tox -- ...`
+    pytest {posargs}


### PR DESCRIPTION
This PR enables running the test suite with [pytest](https://pytest.org), and also sets up the Travis and Appveyor CI to check the package installation and run the tests in isolated virtual environments using [Tox](https://tox.readthedocs.io/en/latest/).
It also prepares Travis for uploading distribution packages automatically upon tags, though the latter is commented-out as the authentication requires someone with push access to the repo

***

Since at least [December 2011](https://github.com/robofab-developers/robofab/commit/f9ec29518c13dfb8a83e040a13a96b47b759a011), robofab has had the version string in the setup.py frozen at `1.2`.
Its spin-off package, ufoLib has inherited the version after the separation, and has kept it like that even after the ufo3 branch was merged a few months ago in master.

ufoLib is a dependency of several other packages, like defcon, ufo2ft, cu2qu, fontMath and booleanOperations (see my graph [here](https://github.com/behdad/fonttools/pull/648#issuecomment-246107751)). So it is a crucial piece in the open source font production toolchain.

When using ufoLib for font production, it is of critical importance to being able to pin down the exact set of requirements needed for building a particular revision of a particular font; as well as being able to reproduce the same result in the future, or on a different local machine or server.

This is why we need an easy, maintainable way for ufoLib developers to release, package and deploy the library for users and other developers to consume in the way they are already familiar with other more mature python projects: that is, installed through pip from the [Python Package Index](https://pypi.org) (PyPI), with clear semantic versions that allow to track and resolve dependencies, freeze and recreate environments, ... [insert here my usual packaging sermon].

I already did something similar with fonttools, compreffor, booleanOperations, and I plan to do it for all the other packages as well.

Tal, I know you are busy. If you grant me push access to this and the other repositories of yours (defcon, fontMath), I can more easily help you out making continuous integration and deployment up and running.
Thank you.