### PR TITLE
specify fonttools 3.1.2 from PyPI in both setup.py and requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-# TODO(anthrotype): replace it with 'fonttools>=3.1' once it's on PyPI
-https://github.com/behdad/fonttools/archive/7930106740f6f6f25583836c56c6cc593762e779.zip
+fonttools==3.1.2

--- a/setup.py
+++ b/setup.py
@@ -38,9 +38,7 @@ setup_params = dict(
 		'pytest>=3.0.2',
 	],
 	install_requires=[
-		# TODO(anthrotype): un-comment this once fonttools>=3.1 is on PyPI.
-		# In the meantime, pip install -r requirements.txt
-		# "fonttools>=3.1",
+		"fonttools>=3.1.2",
 	],
 	classifiers=[
 		"Development Status :: 4 - Beta",


### PR DESCRIPTION
Now that a recent enough version of fonttools is available from PyPI, we can specify it in the setup.py `install_requires` key (so that it's resolved automatically with `pip install ufoLib`), as well as in the `requirements.txt` file.

For the setup.py, we allow any `"fonttools >= 3.1.2"`, so ufoLib can be installed with more recent versions of fonttools as well.

For the `requirements.txt` file, which we use to make our test environment, I fixed the version to `fonttools==3.1.2` (currently the latest one), as the test suite needs to run against explicitly specified requirements.

https://requires.io/ can be used to automate the updating of the requirements.txt, every time a new version of a dependency is published.