### PR TITLE
[pointPen] add identifier=None argument to AbstractPointPen methods

### DIFF
--- a/Lib/ufoLib/pointPen.py
+++ b/Lib/ufoLib/pointPen.py
@@ -23,7 +23,7 @@ class AbstractPointPen(object):
 	Baseclass for all PointPens.
 	"""
 
-	def beginPath(self, identifier=None):
+	def beginPath(self, identifier=None, **kwargs):
 		"""Start a new sub path."""
 		raise NotImplementedError
 
@@ -36,7 +36,8 @@ class AbstractPointPen(object):
 		"""Add a point to the current sub path."""
 		raise NotImplementedError
 
-	def addComponent(self, baseGlyphName, transformation, identifier=None):
+	def addComponent(self, baseGlyphName, transformation, identifier=None,
+					 **kwargs):
 		"""Add a sub glyph."""
 		raise NotImplementedError
 

--- a/Lib/ufoLib/pointPen.py
+++ b/Lib/ufoLib/pointPen.py
@@ -23,7 +23,7 @@ class AbstractPointPen(object):
 	Baseclass for all PointPens.
 	"""
 
-	def beginPath(self):
+	def beginPath(self, identifier=None):
 		"""Start a new sub path."""
 		raise NotImplementedError
 
@@ -31,11 +31,12 @@ class AbstractPointPen(object):
 		"""End the current sub path."""
 		raise NotImplementedError
 
-	def addPoint(self, pt, segmentType=None, smooth=False, name=None, **kwargs):
+	def addPoint(self, pt, segmentType=None, smooth=False, name=None,
+				 identifier=None, **kwargs):
 		"""Add a point to the current sub path."""
 		raise NotImplementedError
 
-	def addComponent(self, baseGlyphName, transformation):
+	def addComponent(self, baseGlyphName, transformation, identifier=None):
 		"""Add a sub glyph."""
 		raise NotImplementedError
 


### PR DESCRIPTION
Fixes https://github.com/unified-font-object/ufoLib/issues/62

I wonder if we should add `**kwargs` to `beginPath` and `addComponent` as well.
`AbstractPointPen.addPoint` has that already, and `glifLib.GLIFPointPen` also has that for `beginPath` and `addComponent`. 

(btw, I hate tabs)