### PR TITLE
[pointPen] make PointToSegmentPen.addComponent accept/ignore **kwargs

### DIFF
--- a/Lib/ufoLib/pointPen.py
+++ b/Lib/ufoLib/pointPen.py
@@ -192,7 +192,7 @@ class PointToSegmentPen(BasePointToSegmentPen):
 		else:
 			pen.endPath()
 
-	def addComponent(self, glyphName, transform):
+	def addComponent(self, glyphName, transform, **kwargs):
 		self.pen.addComponent(glyphName, transform)
 
 


### PR DESCRIPTION
The `beginPath` and `addPoint` methods of `PointToSegmentPen` already take extra `**kwargs` (via `BasePointToSegmentPen`); only the `addComponent` method does not.
This makes it raise `TypeError` when an unknown keyword argument is passed (e.g. 'identifier' for UFO3 objects).
For the `PointToSegmentPen`, which translates between the PointPen and the SegmentPen API, it is ok if we only use the arguments that have an equivalent in the SegmentPen API, and silently discard the extra `**kwargs`.