### PR TITLE
[filesystem] Fix error on opening zip in Python 2

### DIFF
--- a/Lib/ufoLib/filesystem.py
+++ b/Lib/ufoLib/filesystem.py
@@ -75,7 +75,7 @@ class FileSystem(object):
 				path = ZipFS(
 					path, write=True if mode == 'w' else False, encoding="utf8")
 				roots = [
-					p for p in path.listdir("")
+					p for p in path.listdir(u"")
 					# exclude macOS metadata contained in zip file
 					if path.isdir(p) and p != "__MACOSX"
 				]


### PR DESCRIPTION
```python
Python 2.7.13 (default, Jan  6 2017, 13:59:53)
[GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.38)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from ufoLib import UFOReader
>>> r = UFOReader('foo.ufoz')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/mnakamura/.ghq/github.com/mashabow/ufoLib/Lib/ufoLib/__init__.py", line 96, in __init__
    self.fileSystem = FileSystem(path)
  File "/Users/mnakamura/.ghq/github.com/mashabow/ufoLib/Lib/ufoLib/filesystem.py", line 78, in __init__
    p for p in path.listdir("")
  File "/Users/mnakamura/.pyenv/versions/ufoLib-2.7.13/lib/python2.7/site-packages/fs/zipfs.py", line 275, in listdir
    return self._directory.listdir(path)
  File "/Users/mnakamura/.pyenv/versions/ufoLib-2.7.13/lib/python2.7/site-packages/fs/memoryfs.py", line 306, in listdir
    _path = self.validatepath(path)
  File "/Users/mnakamura/.pyenv/versions/ufoLib-2.7.13/lib/python2.7/site-packages/fs/base.py", line 1126, in validatepath
    'paths must be str (not bytes)'
TypeError: paths must be unicode (not str)
```