### PR TITLE
[filesystem] Specify namespaces for getinfo()

### DIFF
--- a/Lib/ufoLib/filesystem.py
+++ b/Lib/ufoLib/filesystem.py
@@ -163,7 +163,7 @@ class FileSystem(object):
 
 	def _fsGetFileModificationTime(self, path):
 		path = self._fsRootPath(path)
-		info = self._fs.getinfo(path)
+		info = self._fs.getinfo(path, namespaces=["details"])
 		return info.modified
 
 	# -----------------
@@ -508,7 +508,7 @@ class _NOFS(object):
 		path = self._absPath(path)
 		return os.listdir(path)
 
-	def getinfo(self, path):
+	def getinfo(self, path, namespaces=None):
 		from fontTools.misc.py23 import SimpleNamespace
 		path = self._absPath(path)
 		stat = os.stat(path)


### PR DESCRIPTION
With `fs.osfs.OSFS`, we have to specify [namespaces](https://pyfilesystem2.readthedocs.io/en/latest/info.html#namespaces) as `["details"]` to get the modification time.

```py
Python 3.6.2 (default, Aug 21 2017, 14:31:44)
[GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.38)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from ufoLib import UFOReader
>>> reader = UFOReader('foo.ufo')
>>> glyph_set = reader.getGlyphSet()
>>> glyph_set.readGlyph('a')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/mnakamura/.ghq/github.com/mashabow/ufoLib/Lib/ufoLib/glifLib.py", line 300, in readGlyph
    text = self.getGLIF(glyphName)
  File "/Users/mnakamura/.ghq/github.com/mashabow/ufoLib/Lib/ufoLib/glifLib.py", line 252, in getGLIF
    self._glifCache[glyphName] = (text, self.fileSystem.getFileModificationTime(path))
  File "/Users/mnakamura/.ghq/github.com/mashabow/ufoLib/Lib/ufoLib/filesystem.py", line 286, in getFileModificationTime
    return self._fsGetFileModificationTime(path)
  File "/Users/mnakamura/.ghq/github.com/mashabow/ufoLib/Lib/ufoLib/filesystem.py", line 167, in _fsGetFileModificationTime
    return info.modified
  File "/Users/mnakamura/.pyenv/versions/ufoLib-3.6.2/lib/python3.6/site-packages/fs/info.py", line 204, in modified
    self._require_namespace('details')
  File "/Users/mnakamura/.pyenv/versions/ufoLib-3.6.2/lib/python3.6/site-packages/fs/info.py", line 87, in _require_namespace
    raise MissingInfoNamespace(namespace)
fs.errors.MissingInfoNamespace: namespace 'details' is required for this attribute
```