### PR TITLE
Catch invalid .plist files

### DIFF
--- a/Lib/ufoLib/glifLib.py
+++ b/Lib/ufoLib/glifLib.py
@@ -995,10 +995,21 @@ def _readNote(glyphObject, note):
 def _readLib(glyphObject, lib):
 	assert len(lib) == 1
 	child = lib[0]
-	plist = readPlistFromTree(child)
-	valid, message = glyphLibValidator(plist)
-	if not valid:
-		raise GlifLibError(message)
+	try:
+		plist = readPlistFromTree(child)
+		valid, message = glyphLibValidator(plist)
+		if not valid:
+			raise GlifLibError(message)
+	except ValueError as e:
+		if hasattr(glyphObject, 'font'):  # for unit tests
+			filename = glyphObject.font.path
+		else:
+			filename = ""
+
+		raise GlifLibError(
+			"{}, glyph '{}': error while reading .glif file"
+			"(ignore line number): {}".format(
+				filename, glyphObject.name, e))
 	_relaxedSetattr(glyphObject, "lib", plist)
 
 def _readImage(glyphObject, image):

--- a/Lib/ufoLib/plistlib.py
+++ b/Lib/ufoLib/plistlib.py
@@ -35,6 +35,20 @@ try:
 			def __init__(self):
 				super().__init__(use_builtin_types=True, dict_type=dict)
 
+				# plistlib in Python >= 3.1 assumes that it will parse plist
+				# files itself instead of being passed a parsed element tree
+				# like done by ufoLib. Exceptions on invalid data are supposed
+				# to include the line number, which is taken from the parser --
+				# that isn't set up in our case, because we parsed the file
+				# already. We therefore have to provide a fake parser object to
+				# get the ValueError exceptions instead of the AttributeError
+				# ones.
+				class FakeParserObject():
+
+					CurrentLineNumber = 0
+
+				self.parser = FakeParserObject()
+
 			def parseElement(self, *args, **kwargs):
 				super().parse_element(*args, **kwargs)
 

--- a/Lib/ufoLib/test/test_GLIF2.py
+++ b/Lib/ufoLib/test/test_GLIF2.py
@@ -351,6 +351,20 @@ class TestGLIF2(unittest.TestCase):
 		self.assertEqual(glif, resultGlif)
 		self.assertEqual(py, resultPy)
 
+	def testLib_illegal(self):
+		glif = """
+		<glyph name="a" format="2">
+			<outline>
+			</outline>
+			<lib>
+				<dict>
+					<key>key</key>
+				</dict>
+			</lib>
+		</glyph>
+		"""
+		self.assertRaises(GlifLibError, self.glifToPy, glif)
+
 	def testGuidelines_legal(self):
 		# legal
 		glif = """


### PR DESCRIPTION
See https://github.com/unified-font-object/ufoLib/issues/140.

Only works in Python >= 3.1 for now: plistlibs from before silently drop erroneous data.

How to handle this? Copy source from plistlib 3.6 into our tree so we get exceptions everywhere?