### PR TITLE
Make validation optional.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ dist/
 *.py[cod]
 .eggs/
 .tox/
+/.pytest_cache

--- a/Lib/ufoLib/__init__.py
+++ b/Lib/ufoLib/__init__.py
@@ -502,7 +502,7 @@ class UFOReader(object):
 		if directory is None:
 			raise UFOLibError("No glyphs directory is mapped to \"%s\"." % layerName)
 		glyphsPath = os.path.join(self._path, directory)
-		return GlyphSet(glyphsPath, ufoFormatVersion=self._formatVersion)
+		return GlyphSet(glyphsPath, ufoFormatVersion=self._formatVersion, validate=validate)
 
 	def getCharacterMapping(self, layerName=None, validate=self._validate):
 		"""
@@ -1118,19 +1118,19 @@ class UFOWriter(object):
 			raise UFOLibError("A layer name must be provided for non-default layers.")
 		# move along to format specific writing
 		if self.formatVersion == 1:
-			return self._getGlyphSetFormatVersion1(glyphNameToFileNameFunc=glyphNameToFileNameFunc)
+			return self._getGlyphSetFormatVersion1(glyphNameToFileNameFunc=glyphNameToFileNameFunc, validate)
 		elif self.formatVersion == 2:
-			return self._getGlyphSetFormatVersion2(glyphNameToFileNameFunc=glyphNameToFileNameFunc)
+			return self._getGlyphSetFormatVersion2(glyphNameToFileNameFunc=glyphNameToFileNameFunc, validate)
 		elif self.formatVersion == 3:
-			return self._getGlyphSetFormatVersion3(layerName=layerName, defaultLayer=defaultLayer, glyphNameToFileNameFunc=glyphNameToFileNameFunc, validate=validate)
+			return self._getGlyphSetFormatVersion3(layerName=layerName, defaultLayer=defaultLayer, glyphNameToFileNameFunc=glyphNameToFileNameFunc, validate)
 
-	def _getGlyphSetFormatVersion1(self, glyphNameToFileNameFunc=None):
+	def _getGlyphSetFormatVersion1(self, glyphNameToFileNameFunc=None, validate):
 		glyphDir = self._makeDirectory(DEFAULT_GLYPHS_DIRNAME)
-		return GlyphSet(glyphDir, glyphNameToFileNameFunc, ufoFormatVersion=1)
+		return GlyphSet(glyphDir, glyphNameToFileNameFunc, ufoFormatVersion=1, validate=validate)
 
-	def _getGlyphSetFormatVersion2(self, glyphNameToFileNameFunc=None):
+	def _getGlyphSetFormatVersion2(self, glyphNameToFileNameFunc=None, validate):
 		glyphDir = self._makeDirectory(DEFAULT_GLYPHS_DIRNAME)
-		return GlyphSet(glyphDir, glyphNameToFileNameFunc, ufoFormatVersion=2)
+		return GlyphSet(glyphDir, glyphNameToFileNameFunc, ufoFormatVersion=2, validate=validate)
 
 	def _getGlyphSetFormatVersion3(self, layerName=None, defaultLayer=True, glyphNameToFileNameFunc=None, validate):
 		# if the default flag is on, make sure that the default in the file

--- a/Lib/ufoLib/glifLib.py
+++ b/Lib/ufoLib/glifLib.py
@@ -104,7 +104,7 @@ class GlyphSet(object):
 
 	glyphClass = Glyph
 
-	def __init__(self, dirName, glyphNameToFileNameFunc=None, ufoFormatVersion=3):
+	def __init__(self, dirName, glyphNameToFileNameFunc=None, ufoFormatVersion=3, validate=False):
 		"""
 		'dirName' should be a path to an existing directory.
 
@@ -124,6 +124,7 @@ class GlyphSet(object):
 		self.rebuildContents()
 		self._reverseContents = None
 		self._glifCache = {}
+		self._validate = validate
 
 	def rebuildContents(self):
 		"""
@@ -136,19 +137,20 @@ class GlyphSet(object):
 			# missing, consider the glyphset empty.
 			contents = {}
 		# validate the contents
-		invalidFormat = False
-		if not isinstance(contents, dict):
-			invalidFormat = True
-		else:
-			for name, fileName in contents.items():
-				if not isinstance(name, basestring):
-					invalidFormat = True
-				if not isinstance(fileName, basestring):
-					invalidFormat = True
-				elif not os.path.exists(os.path.join(self.dirName, fileName)):
-					raise GlifLibError("contents.plist references a file that does not exist: %s" % fileName)
-		if invalidFormat:
-			raise GlifLibError("contents.plist is not properly formatted")
+		if validate:
+			invalidFormat = False
+			if not isinstance(contents, dict):
+				invalidFormat = True
+			else:
+				for name, fileName in contents.items():
+					if not isinstance(name, basestring):
+						invalidFormat = True
+					if not isinstance(fileName, basestring):
+						invalidFormat = True
+					elif not os.path.exists(os.path.join(self.dirName, fileName)):
+						raise GlifLibError("contents.plist references a file that does not 	exist: %s" % fileName)
+			if invalidFormat:
+				raise GlifLibError("contents.plist is not properly formatted")
 		self.contents = contents
 		self._reverseContents = None
 

--- a/Lib/ufoLib/glifLib.py
+++ b/Lib/ufoLib/glifLib.py
@@ -104,7 +104,7 @@ class GlyphSet(object):
 
 	glyphClass = Glyph
 
-	def __init__(self, dirName, glyphNameToFileNameFunc=None, ufoFormatVersion=3, validate=False):
+	def __init__(self, dirName, glyphNameToFileNameFunc=None, ufoFormatVersion=3, validateRead=False, validateWrite=True):
 		"""
 		'dirName' should be a path to an existing directory.
 
@@ -113,6 +113,9 @@ class GlyphSet(object):
 		instance. It should return a file name (including the .glif
 		extension). The glyphNameToFileName function is called whenever
 		a file name is created for a given glyph name.
+
+		``validateRead`` will validate read operations. It's default is ``False``.
+		``validateWrite`` will validate write operations. It's default is ``True``.
 		"""
 		self.dirName = dirName
 		if ufoFormatVersion not in supportedUFOFormatVersions:
@@ -121,15 +124,21 @@ class GlyphSet(object):
 		if glyphNameToFileNameFunc is None:
 			glyphNameToFileNameFunc = glyphNameToFileName
 		self.glyphNameToFileName = glyphNameToFileNameFunc
+		self._validateRead = validateRead
+		self._validateWrite = validateWrite
 		self.rebuildContents()
 		self._reverseContents = None
 		self._glifCache = {}
-		self._validate = validate
 
-	def rebuildContents(self):
+	def rebuildContents(self, validateRead=None):
 		"""
 		Rebuild the contents dict by loading contents.plist.
+
+		``validateRead`` will validate the data, by default it is set to the
+		class's ``validateRead`` value, can be overridden.
 		"""
+		if validateRead is None:
+			validateRead = self._validateRead
 		contentsPath = os.path.join(self.dirName, "contents.plist")
 		try:
 			contents = self._readPlist(contentsPath)
@@ -137,7 +146,7 @@ class GlyphSet(object):
 			# missing, consider the glyphset empty.
 			contents = {}
 		# validate the contents
-		if validate:
+		if validateRead:
 			invalidFormat = False
 			if not isinstance(contents, dict):
 				invalidFormat = True
@@ -181,7 +190,13 @@ class GlyphSet(object):
 
 	# layer info
 
-	def readLayerInfo(self, info):
+	def readLayerInfo(self, info, validateRead=None):
+		"""
+		``validateRead`` will validate the data, by default it is set to the
+		class's ``validateRead`` value, can be overridden.
+		"""
+		if validateRead is None:
+			validateRead = self._validateRead
 		path = os.path.join(self.dirName, LAYERINFO_FILENAME)
 		try:
 			infoDict = self._readPlist(path)
@@ -189,7 +204,8 @@ class GlyphSet(object):
 			return
 		if not isinstance(infoDict, dict):
 			raise GlifLibError("layerinfo.plist is not properly formatted.")
-		infoDict = validateLayerInfoVersion3Data(infoDict)
+		if validateRead:
+			infoDict = validateLayerInfoVersion3Data(infoDict)
 		# populate the object
 		for attr, value in infoDict.items():
 			try:
@@ -197,7 +213,13 @@ class GlyphSet(object):
 			except AttributeError:
 				raise GlifLibError("The supplied layer info object does not support setting a necessary attribute (%s)." % attr)
 
-	def writeLayerInfo(self, info):
+	def writeLayerInfo(self, info, validateWrite=None):
+		"""
+		``validateWrite`` will validate the data, by default it is set to the
+		class's ``validateWrite`` value, can be overridden.
+		"""
+		if validateWrite is None:
+			validateWrite = self._validateWrite
 		if self.ufoFormatVersion < 3:
 			raise GlifLibError("layerinfo.plist is not allowed in UFO %d." % self.ufoFormatVersion)
 		# gather data
@@ -212,7 +234,8 @@ class GlyphSet(object):
 					continue
 				infoData[attr] = value
 		# validate
-		infoData = validateLayerInfoVersion3Data(infoData)
+		if validateWrite:
+			infoData = validateLayerInfoVersion3Data(infoData)
 		# write file
 		path = os.path.join(self.dirName, LAYERINFO_FILENAME)
 		with open(path, "wb") as f:
@@ -271,7 +294,7 @@ class GlyphSet(object):
 
 	# reading/writing API
 
-	def readGlyph(self, glyphName, glyphObject=None, pointPen=None):
+	def readGlyph(self, glyphName, glyphObject=None, pointPen=None, validate=None):
 		"""
 		Read a .glif file for 'glyphName' from the glyph set. The
 		'glyphObject' argument can be any kind of object (even None);
@@ -301,7 +324,12 @@ class GlyphSet(object):
 
 		readGlyph() will raise KeyError if the glyph is not present in
 		the glyph set.
+
+		``validate`` will validate the data, by default it is set to the
+		class's ``validateRead`` value, can be overridden.
 		"""
+		if validate is None:
+			validate = self._validateRead
 		text = self.getGLIF(glyphName)
 		self._purgeCachedGLIF(glyphName)
 		tree = _glifTreeFromString(text)
@@ -309,9 +337,9 @@ class GlyphSet(object):
 			formatVersions = (1,)
 		else:
 			formatVersions = (1, 2)
-		_readGlyphFromTree(tree, glyphObject, pointPen, formatVersions=formatVersions)
+		_readGlyphFromTree(tree, glyphObject, pointPen, formatVersions=formatVersions, validate=validate)
 
-	def writeGlyph(self, glyphName, glyphObject=None, drawPointsFunc=None, formatVersion=None):
+	def writeGlyph(self, glyphName, glyphObject=None, drawPointsFunc=None, formatVersion=None, validate=None):
 		"""
 		Write a .glif file for 'glyphName' to the glyph set. The
 		'glyphObject' argument can be any kind of object (even None);
@@ -338,6 +366,9 @@ class GlyphSet(object):
 		The GLIF format version will be chosen based on the ufoFormatVersion
 		passed during the creation of this object. If a particular format
 		version is desired, it can be passed with the formatVersion argument.
+
+		``validate`` will validate the data, by default it is set to the
+		class's ``validateWrite`` value, can be overridden.
 		"""
 		if formatVersion is None:
 			if self.ufoFormatVersion >= 3:
@@ -349,8 +380,10 @@ class GlyphSet(object):
 				raise GlifLibError("Unsupported GLIF format version: %s" % formatVersion)
 			if formatVersion == 2 and self.ufoFormatVersion < 3:
 				raise GlifLibError("Unsupported GLIF format version (%d) for UFO format version %d." % (formatVersion, self.ufoFormatVersion))
+		if validate is None:
+			validate = self._validateWrite
 		self._purgeCachedGLIF(glyphName)
-		data = writeGlyphToString(glyphName, glyphObject, drawPointsFunc, formatVersion=formatVersion)
+		data = writeGlyphToString(glyphName, glyphObject, drawPointsFunc, formatVersion=formatVersion, validate=validate)
 		fileName = self.contents.get(glyphName)
 		if fileName is None:
 			fileName = self.glyphNameToFileName(glyphName, self)
@@ -479,7 +512,7 @@ def glyphNameToFileName(glyphName, glyphSet):
 # GLIF To and From String
 # -----------------------
 
-def readGlyphFromString(aString, glyphObject=None, pointPen=None, formatVersions=(1, 2)):
+def readGlyphFromString(aString, glyphObject=None, pointPen=None, formatVersions=(1, 2), validate=False):
 	"""
 	Read .glif data from a string into a glyph object.
 
@@ -510,12 +543,14 @@ def readGlyphFromString(aString, glyphObject=None, pointPen=None, formatVersions
 
 	The formatVersions argument defined the GLIF format versions
 	that are allowed to be read.
+
+	``validate`` will validate the read data. It is set to ``False`` by default.
 	"""
 	tree = _glifTreeFromString(aString)
-	_readGlyphFromTree(tree, glyphObject, pointPen, formatVersions=formatVersions)
+	_readGlyphFromTree(tree, glyphObject, pointPen, formatVersions=formatVersions, validate=validate)
 
 
-def writeGlyphToString(glyphName, glyphObject=None, drawPointsFunc=None, writer=None, formatVersion=2):
+def writeGlyphToString(glyphName, glyphObject=None, drawPointsFunc=None, writer=None, formatVersion=2, validate=True):
 	"""
 	Return .glif data for a glyph as a UTF-8 encoded string.
 	The 'glyphObject' argument can be any kind of object (even None);
@@ -540,6 +575,8 @@ def writeGlyphToString(glyphName, glyphObject=None, drawPointsFunc=None, writer=
 	proper PointPen methods to transfer the outline to the .glif file.
 
 	The GLIF format version can be specified with the formatVersion argument.
+
+	``validate`` will validate the written data. It is set to ``True`` by default.
 	"""
 	if writer is None:
 		try:
@@ -569,27 +606,27 @@ def writeGlyphToString(glyphName, glyphObject=None, drawPointsFunc=None, writer=
 		_writeNote(glyphObject, writer)
 	# image
 	if formatVersion >= 2 and getattr(glyphObject, "image", None):
-		_writeImage(glyphObject, writer)
+		_writeImage(glyphObject, writer, validate)
 	# guidelines
 	if formatVersion >= 2 and getattr(glyphObject, "guidelines", None):
-		_writeGuidelines(glyphObject, writer, identifiers)
+		_writeGuidelines(glyphObject, writer, identifiers, validate)
 	# anchors
 	anchors = getattr(glyphObject, "anchors", None)
 	if formatVersion >= 2 and anchors:
-		_writeAnchors(glyphObject, writer, identifiers)
+		_writeAnchors(glyphObject, writer, identifiers, validate)
 	# outline
 	if drawPointsFunc is not None:
 		writer.begintag("outline")
 		writer.newline()
-		pen = GLIFPointPen(writer, identifiers=identifiers)
+		pen = GLIFPointPen(writer, identifiers=identifiers, validate=validate)
 		drawPointsFunc(pen)
 		if formatVersion == 1 and anchors:
-			_writeAnchorsFormat1(pen, anchors)
+			_writeAnchorsFormat1(pen, anchors, validate)
 		writer.endtag("outline")
 		writer.newline()
 	# lib
 	if getattr(glyphObject, "lib", None):
-		_writeLib(glyphObject, writer)
+		_writeLib(glyphObject, writer, validate)
 	# end
 	writer.endtag("glyph")
 	writer.newline()
@@ -650,9 +687,9 @@ def _writeNote(glyphObject, writer):
 	writer.endtag("note")
 	writer.newline()
 
-def _writeImage(glyphObject, writer):
+def _writeImage(glyphObject, writer, validate):
 	image = getattr(glyphObject, "image", None)
-	if not imageValidator(image):
+	if validate and not imageValidator(image):
 		raise GlifLibError("image attribute must be a dict or dict-like object with the proper structure.")
 	attrs = [
 		("fileName", image["fileName"])
@@ -667,9 +704,9 @@ def _writeImage(glyphObject, writer):
 	writer.simpletag("image", attrs)
 	writer.newline()
 
-def _writeGuidelines(glyphObject, writer, identifiers):
+def _writeGuidelines(glyphObject, writer, identifiers, validate):
 	guidelines = getattr(glyphObject, "guidelines", [])
-	if not guidelinesValidator(guidelines):
+	if validate and not guidelinesValidator(guidelines):
 		raise GlifLibError("guidelines attribute does not have the proper structure.")
 	for guideline in guidelines:
 		attrs = []
@@ -697,8 +734,8 @@ def _writeGuidelines(glyphObject, writer, identifiers):
 		writer.simpletag("guideline", attrs)
 		writer.newline()
 
-def _writeAnchorsFormat1(pen, anchors):
-	if not anchorsValidator(anchors):
+def _writeAnchorsFormat1(pen, anchors, validate):
+	if validate and not anchorsValidator(anchors):
 		raise GlifLibError("anchors attribute does not have the proper structure.")
 	for anchor in anchors:
 		attrs = []
@@ -713,9 +750,9 @@ def _writeAnchorsFormat1(pen, anchors):
 		pen.addPoint((x, y), segmentType="move", name=name)
 		pen.endPath()
 
-def _writeAnchors(glyphObject, writer, identifiers):
+def _writeAnchors(glyphObject, writer, identifiers, validate):
 	anchors = getattr(glyphObject, "anchors", [])
-	if not anchorsValidator(anchors):
+	if validate and not anchorsValidator(anchors):
 		raise GlifLibError("anchors attribute does not have the proper structure.")
 	for anchor in anchors:
 		attrs = []
@@ -738,11 +775,12 @@ def _writeAnchors(glyphObject, writer, identifiers):
 		writer.simpletag("anchor", attrs)
 		writer.newline()
 
-def _writeLib(glyphObject, writer):
+def _writeLib(glyphObject, writer, validate):
 	lib = getattr(glyphObject, "lib", None)
-	valid, message = glyphLibValidator(lib)
-	if not valid:
-		raise GlifLibError(message)
+	if validate:
+		valid, message = glyphLibValidator(lib)
+		if not valid:
+			raise GlifLibError(message)
 	if not isinstance(lib, dict):
 		lib = dict(lib)
 	writer.begintag("lib")
@@ -827,7 +865,7 @@ def _glifTreeFromString(aString):
 		raise GlifLibError("Invalid GLIF structure.")
 	return root
 
-def _readGlyphFromTree(tree, glyphObject=None, pointPen=None, formatVersions=(1, 2)):
+def _readGlyphFromTree(tree, glyphObject=None, pointPen=None, formatVersions=(1, 2), validate=False):
 	# check the format version
 	formatVersion = tree.get("format")
 	if formatVersion is None:
@@ -840,14 +878,14 @@ def _readGlyphFromTree(tree, glyphObject=None, pointPen=None, formatVersions=(1,
 	if formatVersion not in formatVersions:
 		raise GlifLibError("Forbidden GLIF format version: %s" % formatVersion)
 	if formatVersion == 1:
-		_readGlyphFromTreeFormat1(tree=tree, glyphObject=glyphObject, pointPen=pointPen)
+		_readGlyphFromTreeFormat1(tree=tree, glyphObject=glyphObject, pointPen=pointPen, validate=validate)
 	elif formatVersion == 2:
-		_readGlyphFromTreeFormat2(tree=tree, glyphObject=glyphObject, pointPen=pointPen)
+		_readGlyphFromTreeFormat2(tree=tree, glyphObject=glyphObject, pointPen=pointPen, validate=validate)
 	else:
 		raise GlifLibError("Unsupported GLIF format version: %s" % formatVersion)
 
 
-def _readGlyphFromTreeFormat1(tree, glyphObject=None, pointPen=None):
+def _readGlyphFromTreeFormat1(tree, glyphObject=None, pointPen=None, validate=None):
 	# get the name
 	_readName(glyphObject, tree)
 	# populate the sub elements
@@ -862,7 +900,7 @@ def _readGlyphFromTreeFormat1(tree, glyphObject=None, pointPen=None):
 			if element.text and element.text.strip() != '':
 				raise GlifLibError("Invalid outline structure.")
 			haveSeenOutline = True
-			buildOutlineFormat1(glyphObject, pointPen, element)
+			buildOutlineFormat1(glyphObject, pointPen, element, validate)
 		elif glyphObject is None:
 			continue
 		elif element.tag == "advance":
@@ -887,14 +925,14 @@ def _readGlyphFromTreeFormat1(tree, glyphObject=None, pointPen=None):
 			if haveSeenLib:
 				raise GlifLibError("The lib element occurs more than once.")
 			haveSeenLib = True
-			_readLib(glyphObject, element)
+			_readLib(glyphObject, element, validate)
 		else:
 			raise GlifLibError("Unknown element in GLIF: %s" % element)
 	# set the collected unicodes
 	if unicodes:
 		_relaxedSetattr(glyphObject, "unicodes", unicodes)
 
-def _readGlyphFromTreeFormat2(tree, glyphObject=None, pointPen=None):
+def _readGlyphFromTreeFormat2(tree, glyphObject=None, pointPen=None, validate=None):
 	# get the name
 	_readName(glyphObject, tree)
 	# populate the sub elements
@@ -913,7 +951,7 @@ def _readGlyphFromTreeFormat2(tree, glyphObject=None, pointPen=None):
 				raise GlifLibError("Invalid outline structure.")
 			haveSeenOutline = True
 			if pointPen is not None:
-				buildOutlineFormat2(glyphObject, pointPen, element, identifiers)
+				buildOutlineFormat2(glyphObject, pointPen, element, identifiers, validate)
 		elif glyphObject is None:
 			continue
 		elif element.tag == "advance":
@@ -949,7 +987,7 @@ def _readGlyphFromTreeFormat2(tree, glyphObject=None, pointPen=None):
 			if len(element):
 				raise GlifLibError("Unknown children in image element.")
 			haveSeenImage = True
-			_readImage(glyphObject, element)
+			_readImage(glyphObject, element, validate)
 		elif element.tag == "note":
 			if haveSeenNote:
 				raise GlifLibError("The note element occurs more than once.")
@@ -959,7 +997,7 @@ def _readGlyphFromTreeFormat2(tree, glyphObject=None, pointPen=None):
 			if haveSeenLib:
 				raise GlifLibError("The lib element occurs more than once.")
 			haveSeenLib = True
-			_readLib(glyphObject, element)
+			_readLib(glyphObject, element, validate)
 		else:
 			raise GlifLibError("Unknown element in GLIF: %s" % element)
 	# set the collected unicodes
@@ -994,21 +1032,22 @@ def _readNote(glyphObject, note):
 	note = "\n".join(line.strip() for line in lines if line.strip())
 	_relaxedSetattr(glyphObject, "note", note)
 
-def _readLib(glyphObject, lib):
+def _readLib(glyphObject, lib, validate):
 	assert len(lib) == 1
 	child = lib[0]
 	plist = readPlistFromTree(child)
-	valid, message = glyphLibValidator(plist)
-	if not valid:
-		raise GlifLibError(message)
+	if validate:
+		valid, message = glyphLibValidator(plist)
+		if not valid:
+			raise GlifLibError(message)
 	_relaxedSetattr(glyphObject, "lib", plist)
 
-def _readImage(glyphObject, image):
+def _readImage(glyphObject, image, validate):
 	imageData = image.attrib
 	for attr, default in _transformationInfo:
 		value = imageData.get(attr, default)
 		imageData[attr] = _number(value)
-	if not imageValidator(imageData):
+	if validate and not imageValidator(imageData):
 		raise GlifLibError("The image element is not properly formatted.")
 	_relaxedSetattr(glyphObject, "image", imageData)
 
@@ -1026,7 +1065,7 @@ pointTypeOptions = set(["move", "line", "offcurve", "curve", "qcurve"])
 
 # format 1
 
-def buildOutlineFormat1(glyphObject, pen, outline):
+def buildOutlineFormat1(glyphObject, pen, outline, validate):
 	anchors = []
 	for element in outline:
 		if element.tag == "contour":
@@ -1038,14 +1077,14 @@ def buildOutlineFormat1(glyphObject, pen, outline):
 						anchors.append(anchor)
 						continue
 			if pen is not None:
-				_buildOutlineContourFormat1(pen, element)
+				_buildOutlineContourFormat1(pen, element, validate)
 		elif element.tag == "component":
 			if pen is not None:
 				_buildOutlineComponentFormat1(pen, element)
 		else:
 			raise GlifLibError("Unknown element in outline element: %s" % element)
 	if glyphObject is not None and anchors:
-		if not anchorsValidator(anchors):
+		if validate and not anchorsValidator(anchors):
 			raise GlifLibError("GLIF 1 anchors are not properly formatted.")
 		_relaxedSetattr(glyphObject, "anchors", anchors)
 
@@ -1066,7 +1105,7 @@ def _buildAnchorFormat1(point):
 	anchor = dict(x=x, y=y, name=name)
 	return anchor
 
-def _buildOutlineContourFormat1(pen, contour):
+def _buildOutlineContourFormat1(pen, contour, validate):
 	if contour.attrib:
 		raise GlifLibError("Unknown attributes in contour element.")
 	pen.beginPath()
@@ -1105,16 +1144,16 @@ def _buildOutlineComponentFormat1(pen, component):
 
 # format 2
 
-def buildOutlineFormat2(glyphObject, pen, outline, identifiers):
+def buildOutlineFormat2(glyphObject, pen, outline, identifiers, validate):
 	for element in outline:
 		if element.tag == "contour":
-			_buildOutlineContourFormat2(pen, element, identifiers)
+			_buildOutlineContourFormat2(pen, element, identifiers, validate)
 		elif element.tag == "component":
-			_buildOutlineComponentFormat2(pen, element, identifiers)
+			_buildOutlineComponentFormat2(pen, element, identifiers, validate)
 		else:
 			raise GlifLibError("Unknown element in outline element: %s" % element.tag)
 
-def _buildOutlineContourFormat2(pen, contour, identifiers):
+def _buildOutlineContourFormat2(pen, contour, identifiers, validate):
 	for attr in contour.attrib.keys():
 		if attr not in contourAttributesFormat2:
 			raise GlifLibError("Unknown attribute in contour element: %s" % attr)
@@ -1122,7 +1161,7 @@ def _buildOutlineContourFormat2(pen, contour, identifiers):
 	if identifier is not None:
 		if identifier in identifiers:
 			raise GlifLibError("The identifier %s is used more than once." % identifier)
-		if not identifierValidator(identifier):
+		if validate and not identifierValidator(identifier):
 			raise GlifLibError("The contour identifier %s is not valid." % identifier)
 		identifiers.add(identifier)
 	try:
@@ -1132,10 +1171,10 @@ def _buildOutlineContourFormat2(pen, contour, identifiers):
 		warn("The beginPath method needs an identifier kwarg. The contour's identifier value has been discarded.", DeprecationWarning)
 	if len(contour):
 		_validateAndMassagePointStructures(contour, pointAttributesFormat2)
-		_buildOutlinePointsFormat2(pen, contour, identifiers)
+		_buildOutlinePointsFormat2(pen, contour, identifiers, validate)
 	pen.endPath()
 
-def _buildOutlinePointsFormat2(pen, contour, identifiers):
+def _buildOutlinePointsFormat2(pen, contour, identifiers, validate):
 	for element in contour:
 		x = element.attrib["x"]
 		y = element.attrib["y"]
@@ -1146,7 +1185,7 @@ def _buildOutlinePointsFormat2(pen, contour, identifiers):
 		if identifier is not None:
 			if identifier in identifiers:
 				raise GlifLibError("The identifier %s is used more than once." % identifier)
-			if not identifierValidator(identifier):
+			if validate and not identifierValidator(identifier):
 				raise GlifLibError("The identifier %s is not valid." % identifier)
 			identifiers.add(identifier)
 		try:
@@ -1155,7 +1194,7 @@ def _buildOutlinePointsFormat2(pen, contour, identifiers):
 			pen.addPoint((x, y), segmentType=segmentType, smooth=smooth, name=name)
 			warn("The addPoint method needs an identifier kwarg. The point's identifier value has been discarded.", DeprecationWarning)
 
-def _buildOutlineComponentFormat2(pen, component, identifiers):
+def _buildOutlineComponentFormat2(pen, component, identifiers, validate):
 	if len(component):
 		raise GlifLibError("Unknown child elements of component element.")
 	for attr in component.attrib.keys():
@@ -1176,7 +1215,7 @@ def _buildOutlineComponentFormat2(pen, component, identifiers):
 	if identifier is not None:
 		if identifier in identifiers:
 			raise GlifLibError("The identifier %s is used more than once." % identifier)
-		if not identifierValidator(identifier):
+		if validate and not identifierValidator(identifier):
 			raise GlifLibError("The identifier %s is not valid." % identifier)
 		identifiers.add(identifier)
 	try:
@@ -1443,7 +1482,7 @@ class GLIFPointPen(AbstractPointPen):
 	part of .glif files.
 	"""
 
-	def __init__(self, xmlWriter, formatVersion=2, identifiers=None):
+	def __init__(self, xmlWriter, formatVersion=2, identifiers=None, validate=True):
 		if identifiers is None:
 			identifiers = set()
 		self.formatVersion = formatVersion
@@ -1451,13 +1490,14 @@ class GLIFPointPen(AbstractPointPen):
 		self.writer = xmlWriter
 		self.prevOffCurveCount = 0
 		self.prevPointTypes = []
+		self.validate = validate
 
 	def beginPath(self, identifier=None, **kwargs):
 		attrs = []
 		if identifier is not None and self.formatVersion >= 2:
 			if identifier in self.identifiers:
 				raise GlifLibError("identifier used more than once: %s" % identifier)
-			if not identifierValidator(identifier):
+			if self.validate and not identifierValidator(identifier):
 				raise GlifLibError("identifier not formatted properly: %s" % identifier)
 			attrs.append(("identifier", identifier))
 			self.identifiers.add(identifier)
@@ -1514,7 +1554,7 @@ class GLIFPointPen(AbstractPointPen):
 		if identifier is not None and self.formatVersion >= 2:
 			if identifier in self.identifiers:
 				raise GlifLibError("identifier used more than once: %s" % identifier)
-			if not identifierValidator(identifier):
+			if self.validate and not identifierValidator(identifier):
 				raise GlifLibError("identifier not formatted properly: %s" % identifier)
 			attrs.append(("identifier", identifier))
 			self.identifiers.add(identifier)
@@ -1531,7 +1571,7 @@ class GLIFPointPen(AbstractPointPen):
 		if identifier is not None and self.formatVersion >= 2:
 			if identifier in self.identifiers:
 				raise GlifLibError("identifier used more than once: %s" % identifier)
-			if not identifierValidator(identifier):
+			if self.validate and not identifierValidator(identifier):
 				raise GlifLibError("identifier not formatted properly: %s" % identifier)
 			attrs.append(("identifier", identifier))
 			self.identifiers.add(identifier)

--- a/Lib/ufoLib/test/test_GLIF2.py
+++ b/Lib/ufoLib/test/test_GLIF2.py
@@ -32,7 +32,7 @@ class TestGLIF2(unittest.TestCase):
 		glif = stripText(glif)
 		glif = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + glif
 		glyph = Glyph()
-		readGlyphFromString(glif, glyphObject=glyph, pointPen=glyph)
+		readGlyphFromString(glif, glyphObject=glyph, pointPen=glyph, validate=True)
 		return glyph.py()
 
 	def testTopElement(self):

--- a/Lib/ufoLib/test/test_UFO1.py
+++ b/Lib/ufoLib/test/test_UFO1.py
@@ -37,7 +37,7 @@ class ReadFontInfoVersion1TestCase(unittest.TestCase):
 		originalData = dict(fontInfoVersion1)
 		self._writeInfoToPlist(originalData)
 		infoObject = TestInfoObject()
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		reader.readInfo(infoObject)
 		for attr in dir(infoObject):
 			if attr not in fontInfoVersion2:
@@ -57,7 +57,7 @@ class ReadFontInfoVersion1TestCase(unittest.TestCase):
 			info = dict(fontInfoVersion1)
 			info["fontStyle"] = old
 			self._writeInfoToPlist(info)
-			reader = UFOReader(self.dstDir)
+			reader = UFOReader(self.dstDir, validate=True)
 			infoObject = TestInfoObject()
 			reader.readInfo(infoObject)
 			self.assertEqual(new, infoObject.styleMapStyleName)
@@ -78,7 +78,7 @@ class ReadFontInfoVersion1TestCase(unittest.TestCase):
 			info = dict(fontInfoVersion1)
 			info["widthName"] = old
 			self._writeInfoToPlist(info)
-			reader = UFOReader(self.dstDir)
+			reader = UFOReader(self.dstDir, validate=True)
 			infoObject = TestInfoObject()
 			reader.readInfo(infoObject)
 			self.assertEqual(new, infoObject.openTypeOS2WidthClass)

--- a/Lib/ufoLib/test/test_UFO2.py
+++ b/Lib/ufoLib/test/test_UFO2.py
@@ -37,7 +37,7 @@ class ReadFontInfoVersion2TestCase(unittest.TestCase):
 		originalData = dict(fontInfoVersion2)
 		self._writeInfoToPlist(originalData)
 		infoObject = TestInfoObject()
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		reader.readInfo(infoObject)
 		readData = {}
 		for attr in list(fontInfoVersion2.keys()):
@@ -49,92 +49,92 @@ class ReadFontInfoVersion2TestCase(unittest.TestCase):
 		info = dict(fontInfoVersion2)
 		info["familyName"] = 123
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# styleName
 		info = dict(fontInfoVersion2)
 		info["styleName"] = 123
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# styleMapFamilyName
 		info = dict(fontInfoVersion2)
 		info["styleMapFamilyName"] = 123
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# styleMapStyleName
 		## not a string
 		info = dict(fontInfoVersion2)
 		info["styleMapStyleName"] = 123
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		## out of range
 		info = dict(fontInfoVersion2)
 		info["styleMapStyleName"] = "REGULAR"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# versionMajor
 		info = dict(fontInfoVersion2)
 		info["versionMajor"] = "1"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# versionMinor
 		info = dict(fontInfoVersion2)
 		info["versionMinor"] = "0"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# copyright
 		info = dict(fontInfoVersion2)
 		info["copyright"] = 123
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# trademark
 		info = dict(fontInfoVersion2)
 		info["trademark"] = 123
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# unitsPerEm
 		info = dict(fontInfoVersion2)
 		info["unitsPerEm"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# descender
 		info = dict(fontInfoVersion2)
 		info["descender"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# xHeight
 		info = dict(fontInfoVersion2)
 		info["xHeight"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# capHeight
 		info = dict(fontInfoVersion2)
 		info["capHeight"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# ascender
 		info = dict(fontInfoVersion2)
 		info["ascender"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# italicAngle
 		info = dict(fontInfoVersion2)
 		info["italicAngle"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 
 	def testHeadRead(self):
@@ -143,25 +143,25 @@ class ReadFontInfoVersion2TestCase(unittest.TestCase):
 		info = dict(fontInfoVersion2)
 		info["openTypeHeadCreated"] = 123
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		## invalid format
 		info = dict(fontInfoVersion2)
 		info["openTypeHeadCreated"] = "2000-Jan-01 00:00:00"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeHeadLowestRecPPEM
 		info = dict(fontInfoVersion2)
 		info["openTypeHeadLowestRecPPEM"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeHeadFlags
 		info = dict(fontInfoVersion2)
 		info["openTypeHeadFlags"] = [-1]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 
 	def testHheaRead(self):
@@ -169,37 +169,37 @@ class ReadFontInfoVersion2TestCase(unittest.TestCase):
 		info = dict(fontInfoVersion2)
 		info["openTypeHheaAscender"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeHheaDescender
 		info = dict(fontInfoVersion2)
 		info["openTypeHheaDescender"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeHheaLineGap
 		info = dict(fontInfoVersion2)
 		info["openTypeHheaLineGap"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeHheaCaretSlopeRise
 		info = dict(fontInfoVersion2)
 		info["openTypeHheaCaretSlopeRise"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeHheaCaretSlopeRun
 		info = dict(fontInfoVersion2)
 		info["openTypeHheaCaretSlopeRun"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeHheaCaretOffset
 		info = dict(fontInfoVersion2)
 		info["openTypeHheaCaretOffset"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 
 	def testNameRead(self):
@@ -207,91 +207,91 @@ class ReadFontInfoVersion2TestCase(unittest.TestCase):
 		info = dict(fontInfoVersion2)
 		info["openTypeNameDesigner"] = 123
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeNameDesignerURL
 		info = dict(fontInfoVersion2)
 		info["openTypeNameDesignerURL"] = 123
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeNameManufacturer
 		info = dict(fontInfoVersion2)
 		info["openTypeNameManufacturer"] = 123
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeNameManufacturerURL
 		info = dict(fontInfoVersion2)
 		info["openTypeNameManufacturerURL"] = 123
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeNameLicense
 		info = dict(fontInfoVersion2)
 		info["openTypeNameLicense"] = 123
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeNameLicenseURL
 		info = dict(fontInfoVersion2)
 		info["openTypeNameLicenseURL"] = 123
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeNameVersion
 		info = dict(fontInfoVersion2)
 		info["openTypeNameVersion"] = 123
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeNameUniqueID
 		info = dict(fontInfoVersion2)
 		info["openTypeNameUniqueID"] = 123
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeNameDescription
 		info = dict(fontInfoVersion2)
 		info["openTypeNameDescription"] = 123
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeNamePreferredFamilyName
 		info = dict(fontInfoVersion2)
 		info["openTypeNamePreferredFamilyName"] = 123
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeNamePreferredSubfamilyName
 		info = dict(fontInfoVersion2)
 		info["openTypeNamePreferredSubfamilyName"] = 123
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeNameCompatibleFullName
 		info = dict(fontInfoVersion2)
 		info["openTypeNameCompatibleFullName"] = 123
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeNameSampleText
 		info = dict(fontInfoVersion2)
 		info["openTypeNameSampleText"] = 123
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeNameWWSFamilyName
 		info = dict(fontInfoVersion2)
 		info["openTypeNameWWSFamilyName"] = 123
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeNameWWSSubfamilyName
 		info = dict(fontInfoVersion2)
 		info["openTypeNameWWSSubfamilyName"] = 123
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 
 	def testOS2Read(self):
@@ -300,210 +300,210 @@ class ReadFontInfoVersion2TestCase(unittest.TestCase):
 		info = dict(fontInfoVersion2)
 		info["openTypeOS2WidthClass"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		## out or range
 		info = dict(fontInfoVersion2)
 		info["openTypeOS2WidthClass"] = 15
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeOS2WeightClass
 		info = dict(fontInfoVersion2)
 		## not an int
 		info["openTypeOS2WeightClass"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		## out of range
 		info["openTypeOS2WeightClass"] = -50
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeOS2Selection
 		info = dict(fontInfoVersion2)
 		info["openTypeOS2Selection"] = [-1]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeOS2VendorID
 		info = dict(fontInfoVersion2)
 		info["openTypeOS2VendorID"] = 1234
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeOS2Panose
 		## not an int
 		info = dict(fontInfoVersion2)
 		info["openTypeOS2Panose"] = [0, 1, 2, 3, 4, 5, 6, 7, 8, str(9)]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		## too few values
 		info = dict(fontInfoVersion2)
 		info["openTypeOS2Panose"] = [0, 1, 2, 3]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		## too many values
 		info = dict(fontInfoVersion2)
 		info["openTypeOS2Panose"] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeOS2FamilyClass
 		## not an int
 		info = dict(fontInfoVersion2)
 		info["openTypeOS2FamilyClass"] = [1, str(1)]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		## too few values
 		info = dict(fontInfoVersion2)
 		info["openTypeOS2FamilyClass"] = [1]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		## too many values
 		info = dict(fontInfoVersion2)
 		info["openTypeOS2FamilyClass"] = [1, 1, 1]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		## out of range
 		info = dict(fontInfoVersion2)
 		info["openTypeOS2FamilyClass"] = [1, 201]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeOS2UnicodeRanges
 		## not an int
 		info = dict(fontInfoVersion2)
 		info["openTypeOS2UnicodeRanges"] = ["0"]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		## out of range
 		info = dict(fontInfoVersion2)
 		info["openTypeOS2UnicodeRanges"] = [-1]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeOS2CodePageRanges
 		## not an int
 		info = dict(fontInfoVersion2)
 		info["openTypeOS2CodePageRanges"] = ["0"]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		## out of range
 		info = dict(fontInfoVersion2)
 		info["openTypeOS2CodePageRanges"] = [-1]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeOS2TypoAscender
 		info = dict(fontInfoVersion2)
 		info["openTypeOS2TypoAscender"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeOS2TypoDescender
 		info = dict(fontInfoVersion2)
 		info["openTypeOS2TypoDescender"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeOS2TypoLineGap
 		info = dict(fontInfoVersion2)
 		info["openTypeOS2TypoLineGap"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeOS2WinAscent
 		info = dict(fontInfoVersion2)
 		info["openTypeOS2WinAscent"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeOS2WinDescent
 		info = dict(fontInfoVersion2)
 		info["openTypeOS2WinDescent"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeOS2Type
 		## not an int
 		info = dict(fontInfoVersion2)
 		info["openTypeOS2Type"] = ["1"]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		## out of range
 		info = dict(fontInfoVersion2)
 		info["openTypeOS2Type"] = [-1]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeOS2SubscriptXSize
 		info = dict(fontInfoVersion2)
 		info["openTypeOS2SubscriptXSize"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeOS2SubscriptYSize
 		info = dict(fontInfoVersion2)
 		info["openTypeOS2SubscriptYSize"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeOS2SubscriptXOffset
 		info = dict(fontInfoVersion2)
 		info["openTypeOS2SubscriptXOffset"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeOS2SubscriptYOffset
 		info = dict(fontInfoVersion2)
 		info["openTypeOS2SubscriptYOffset"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeOS2SuperscriptXSize
 		info = dict(fontInfoVersion2)
 		info["openTypeOS2SuperscriptXSize"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeOS2SuperscriptYSize
 		info = dict(fontInfoVersion2)
 		info["openTypeOS2SuperscriptYSize"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeOS2SuperscriptXOffset
 		info = dict(fontInfoVersion2)
 		info["openTypeOS2SuperscriptXOffset"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeOS2SuperscriptYOffset
 		info = dict(fontInfoVersion2)
 		info["openTypeOS2SuperscriptYOffset"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeOS2StrikeoutSize
 		info = dict(fontInfoVersion2)
 		info["openTypeOS2StrikeoutSize"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeOS2StrikeoutPosition
 		info = dict(fontInfoVersion2)
 		info["openTypeOS2StrikeoutPosition"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 
 	def testVheaRead(self):
@@ -511,37 +511,37 @@ class ReadFontInfoVersion2TestCase(unittest.TestCase):
 		info = dict(fontInfoVersion2)
 		info["openTypeVheaVertTypoAscender"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeVheaVertTypoDescender
 		info = dict(fontInfoVersion2)
 		info["openTypeVheaVertTypoDescender"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeVheaVertTypoLineGap
 		info = dict(fontInfoVersion2)
 		info["openTypeVheaVertTypoLineGap"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeVheaCaretSlopeRise
 		info = dict(fontInfoVersion2)
 		info["openTypeVheaCaretSlopeRise"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeVheaCaretSlopeRun
 		info = dict(fontInfoVersion2)
 		info["openTypeVheaCaretSlopeRun"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeVheaCaretOffset
 		info = dict(fontInfoVersion2)
 		info["openTypeVheaCaretOffset"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 
 	def testFONDRead(self):
@@ -549,13 +549,13 @@ class ReadFontInfoVersion2TestCase(unittest.TestCase):
 		info = dict(fontInfoVersion2)
 		info["macintoshFONDFamilyID"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# macintoshFONDName
 		info = dict(fontInfoVersion2)
 		info["macintoshFONDName"] = 123
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 
 	def testPostscriptRead(self):
@@ -563,211 +563,211 @@ class ReadFontInfoVersion2TestCase(unittest.TestCase):
 		info = dict(fontInfoVersion2)
 		info["postscriptFontName"] = 123
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# postscriptFullName
 		info = dict(fontInfoVersion2)
 		info["postscriptFullName"] = 123
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# postscriptSlantAngle
 		info = dict(fontInfoVersion2)
 		info["postscriptSlantAngle"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# postscriptUniqueID
 		info = dict(fontInfoVersion2)
 		info["postscriptUniqueID"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		# postscriptUnderlineThickness
 		info = dict(fontInfoVersion2)
 		info["postscriptUnderlineThickness"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		# postscriptUnderlinePosition
 		info = dict(fontInfoVersion2)
 		info["postscriptUnderlinePosition"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		# postscriptIsFixedPitch
 		info = dict(fontInfoVersion2)
 		info["postscriptIsFixedPitch"] = 2
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		# postscriptBlueValues
 		## not a list
 		info = dict(fontInfoVersion2)
 		info["postscriptBlueValues"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## uneven value count
 		info = dict(fontInfoVersion2)
 		info["postscriptBlueValues"] = [500]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## too many values
 		info = dict(fontInfoVersion2)
 		info["postscriptBlueValues"] = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		# postscriptOtherBlues
 		## not a list
 		info = dict(fontInfoVersion2)
 		info["postscriptOtherBlues"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## uneven value count
 		info = dict(fontInfoVersion2)
 		info["postscriptOtherBlues"] = [500]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## too many values
 		info = dict(fontInfoVersion2)
 		info["postscriptOtherBlues"] = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		# postscriptFamilyBlues
 		## not a list
 		info = dict(fontInfoVersion2)
 		info["postscriptFamilyBlues"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## uneven value count
 		info = dict(fontInfoVersion2)
 		info["postscriptFamilyBlues"] = [500]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## too many values
 		info = dict(fontInfoVersion2)
 		info["postscriptFamilyBlues"] = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		# postscriptFamilyOtherBlues
 		## not a list
 		info = dict(fontInfoVersion2)
 		info["postscriptFamilyOtherBlues"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## uneven value count
 		info = dict(fontInfoVersion2)
 		info["postscriptFamilyOtherBlues"] = [500]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## too many values
 		info = dict(fontInfoVersion2)
 		info["postscriptFamilyOtherBlues"] = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		# postscriptStemSnapH
 		## not list
 		info = dict(fontInfoVersion2)
 		info["postscriptStemSnapH"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## too many values
 		info = dict(fontInfoVersion2)
 		info["postscriptStemSnapH"] = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		# postscriptStemSnapV
 		## not list
 		info = dict(fontInfoVersion2)
 		info["postscriptStemSnapV"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## too many values
 		info = dict(fontInfoVersion2)
 		info["postscriptStemSnapV"] = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		# postscriptBlueFuzz
 		info = dict(fontInfoVersion2)
 		info["postscriptBlueFuzz"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		# postscriptBlueShift
 		info = dict(fontInfoVersion2)
 		info["postscriptBlueShift"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		# postscriptBlueScale
 		info = dict(fontInfoVersion2)
 		info["postscriptBlueScale"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		# postscriptForceBold
 		info = dict(fontInfoVersion2)
 		info["postscriptForceBold"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		# postscriptDefaultWidthX
 		info = dict(fontInfoVersion2)
 		info["postscriptDefaultWidthX"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		# postscriptNominalWidthX
 		info = dict(fontInfoVersion2)
 		info["postscriptNominalWidthX"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		# postscriptWeightName
 		info = dict(fontInfoVersion2)
 		info["postscriptWeightName"] = 123
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		# postscriptDefaultCharacter
 		info = dict(fontInfoVersion2)
 		info["postscriptDefaultCharacter"] = 123
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		# postscriptWindowsCharacterSet
 		info = dict(fontInfoVersion2)
 		info["postscriptWindowsCharacterSet"] = -1
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		# macintoshFONDFamilyID
 		info = dict(fontInfoVersion2)
 		info["macintoshFONDFamilyID"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		# macintoshFONDName
 		info = dict(fontInfoVersion2)
 		info["macintoshFONDName"] = 123
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 
 

--- a/Lib/ufoLib/test/test_UFO3.py
+++ b/Lib/ufoLib/test/test_UFO3.py
@@ -43,7 +43,7 @@ class ReadFontInfoVersion3TestCase(unittest.TestCase):
 		originalData = dict(fontInfoVersion3)
 		self._writeInfoToPlist(originalData)
 		infoObject = TestInfoObject()
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		reader.readInfo(infoObject)
 		readData = {}
 		for attr in list(fontInfoVersion3.keys()):
@@ -55,107 +55,107 @@ class ReadFontInfoVersion3TestCase(unittest.TestCase):
 		info = dict(fontInfoVersion3)
 		info["familyName"] = 123
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# styleName
 		info = dict(fontInfoVersion3)
 		info["styleName"] = 123
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# styleMapFamilyName
 		info = dict(fontInfoVersion3)
 		info["styleMapFamilyName"] = 123
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# styleMapStyleName
 		## not a string
 		info = dict(fontInfoVersion3)
 		info["styleMapStyleName"] = 123
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		## out of range
 		info = dict(fontInfoVersion3)
 		info["styleMapStyleName"] = "REGULAR"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# versionMajor
 		info = dict(fontInfoVersion3)
 		info["versionMajor"] = "1"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# versionMinor
 		info = dict(fontInfoVersion3)
 		info["versionMinor"] = "0"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		info = dict(fontInfoVersion3)
 		info["versionMinor"] = -1
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# copyright
 		info = dict(fontInfoVersion3)
 		info["copyright"] = 123
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# trademark
 		info = dict(fontInfoVersion3)
 		info["trademark"] = 123
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# unitsPerEm
 		info = dict(fontInfoVersion3)
 		info["unitsPerEm"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		info = dict(fontInfoVersion3)
 		info["unitsPerEm"] = -1
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		info = dict(fontInfoVersion3)
 		info["unitsPerEm"] = -1.0
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# descender
 		info = dict(fontInfoVersion3)
 		info["descender"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# xHeight
 		info = dict(fontInfoVersion3)
 		info["xHeight"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# capHeight
 		info = dict(fontInfoVersion3)
 		info["capHeight"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# ascender
 		info = dict(fontInfoVersion3)
 		info["ascender"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# italicAngle
 		info = dict(fontInfoVersion3)
 		info["italicAngle"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 
 	def testGaspRead(self):
@@ -163,60 +163,60 @@ class ReadFontInfoVersion3TestCase(unittest.TestCase):
 		info = dict(fontInfoVersion3)
 		info["openTypeGaspRangeRecords"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# empty list
 		info = dict(fontInfoVersion3)
 		info["openTypeGaspRangeRecords"] = []
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		reader.readInfo(TestInfoObject())
 		# not a dict
 		info = dict(fontInfoVersion3)
 		info["openTypeGaspRangeRecords"] = ["abc"]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# dict not properly formatted
 		info = dict(fontInfoVersion3)
 		info["openTypeGaspRangeRecords"] = [dict(rangeMaxPPEM=0xFFFF, notTheRightKey=1)]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		info = dict(fontInfoVersion3)
 		info["openTypeGaspRangeRecords"] = [dict(notTheRightKey=1, rangeGaspBehavior=[0])]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# not an int for ppem
 		info = dict(fontInfoVersion3)
 		info["openTypeGaspRangeRecords"] = [dict(rangeMaxPPEM="abc", rangeGaspBehavior=[0]), dict(rangeMaxPPEM=0xFFFF, rangeGaspBehavior=[0])]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# not a list for behavior
 		info = dict(fontInfoVersion3)
 		info["openTypeGaspRangeRecords"] = [dict(rangeMaxPPEM=10, rangeGaspBehavior="abc"), dict(rangeMaxPPEM=0xFFFF, rangeGaspBehavior=[0])]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# invalid behavior value
 		info = dict(fontInfoVersion3)
 		info["openTypeGaspRangeRecords"] = [dict(rangeMaxPPEM=10, rangeGaspBehavior=[-1]), dict(rangeMaxPPEM=0xFFFF, rangeGaspBehavior=[0])]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# not sorted
 		info = dict(fontInfoVersion3)
 		info["openTypeGaspRangeRecords"] = [dict(rangeMaxPPEM=0xFFFF, rangeGaspBehavior=[0]), dict(rangeMaxPPEM=10, rangeGaspBehavior=[0])]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# no 0xFFFF
 		info = dict(fontInfoVersion3)
 		info["openTypeGaspRangeRecords"] = [dict(rangeMaxPPEM=10, rangeGaspBehavior=[0]), dict(rangeMaxPPEM=20, rangeGaspBehavior=[0])]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		reader.readInfo(TestInfoObject())
 
 	def testHeadRead(self):
@@ -225,30 +225,30 @@ class ReadFontInfoVersion3TestCase(unittest.TestCase):
 		info = dict(fontInfoVersion3)
 		info["openTypeHeadCreated"] = 123
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		## invalid format
 		info = dict(fontInfoVersion3)
 		info["openTypeHeadCreated"] = "2000-Jan-01 00:00:00"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeHeadLowestRecPPEM
 		info = dict(fontInfoVersion3)
 		info["openTypeHeadLowestRecPPEM"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		info = dict(fontInfoVersion3)
 		info["openTypeHeadLowestRecPPEM"] = -1
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeHeadFlags
 		info = dict(fontInfoVersion3)
 		info["openTypeHeadFlags"] = [-1]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 
 	def testHheaRead(self):
@@ -256,37 +256,37 @@ class ReadFontInfoVersion3TestCase(unittest.TestCase):
 		info = dict(fontInfoVersion3)
 		info["openTypeHheaAscender"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeHheaDescender
 		info = dict(fontInfoVersion3)
 		info["openTypeHheaDescender"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeHheaLineGap
 		info = dict(fontInfoVersion3)
 		info["openTypeHheaLineGap"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeHheaCaretSlopeRise
 		info = dict(fontInfoVersion3)
 		info["openTypeHheaCaretSlopeRise"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeHheaCaretSlopeRun
 		info = dict(fontInfoVersion3)
 		info["openTypeHheaCaretSlopeRun"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeHheaCaretOffset
 		info = dict(fontInfoVersion3)
 		info["openTypeHheaCaretOffset"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 
 	def testNameRead(self):
@@ -294,110 +294,110 @@ class ReadFontInfoVersion3TestCase(unittest.TestCase):
 		info = dict(fontInfoVersion3)
 		info["openTypeNameDesigner"] = 123
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeNameDesignerURL
 		info = dict(fontInfoVersion3)
 		info["openTypeNameDesignerURL"] = 123
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeNameManufacturer
 		info = dict(fontInfoVersion3)
 		info["openTypeNameManufacturer"] = 123
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeNameManufacturerURL
 		info = dict(fontInfoVersion3)
 		info["openTypeNameManufacturerURL"] = 123
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeNameLicense
 		info = dict(fontInfoVersion3)
 		info["openTypeNameLicense"] = 123
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeNameLicenseURL
 		info = dict(fontInfoVersion3)
 		info["openTypeNameLicenseURL"] = 123
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeNameVersion
 		info = dict(fontInfoVersion3)
 		info["openTypeNameVersion"] = 123
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeNameUniqueID
 		info = dict(fontInfoVersion3)
 		info["openTypeNameUniqueID"] = 123
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeNameDescription
 		info = dict(fontInfoVersion3)
 		info["openTypeNameDescription"] = 123
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeNamePreferredFamilyName
 		info = dict(fontInfoVersion3)
 		info["openTypeNamePreferredFamilyName"] = 123
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeNamePreferredSubfamilyName
 		info = dict(fontInfoVersion3)
 		info["openTypeNamePreferredSubfamilyName"] = 123
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeNameCompatibleFullName
 		info = dict(fontInfoVersion3)
 		info["openTypeNameCompatibleFullName"] = 123
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeNameSampleText
 		info = dict(fontInfoVersion3)
 		info["openTypeNameSampleText"] = 123
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeNameWWSFamilyName
 		info = dict(fontInfoVersion3)
 		info["openTypeNameWWSFamilyName"] = 123
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeNameWWSSubfamilyName
 		info = dict(fontInfoVersion3)
 		info["openTypeNameWWSSubfamilyName"] = 123
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeNameRecords
 		## not a list
 		info = dict(fontInfoVersion3)
 		info["openTypeNameRecords"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		## not a dict
 		info = dict(fontInfoVersion3)
 		info["openTypeNameRecords"] = ["abc"]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		## invalid dict structure
 		info = dict(fontInfoVersion3)
 		info["openTypeNameRecords"] = [dict(foo="bar")]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		## incorrect keys
 		info = dict(fontInfoVersion3)
@@ -405,42 +405,42 @@ class ReadFontInfoVersion3TestCase(unittest.TestCase):
 			dict(nameID=1, platformID=1, encodingID=1, languageID=1, string="Name Record.", foo="bar")
 		]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		info = dict(fontInfoVersion3)
 		info["openTypeNameRecords"] = [
 			dict(platformID=1, encodingID=1, languageID=1, string="Name Record.")
 		]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		info = dict(fontInfoVersion3)
 		info["openTypeNameRecords"] = [
 			dict(nameID=1, encodingID=1, languageID=1, string="Name Record.")
 		]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		info = dict(fontInfoVersion3)
 		info["openTypeNameRecords"] = [
 			dict(nameID=1, platformID=1, languageID=1, string="Name Record.")
 		]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		info = dict(fontInfoVersion3)
 		info["openTypeNameRecords"] = [
 			dict(nameID=1, platformID=1, encodingID=1, string="Name Record.")
 		]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		info = dict(fontInfoVersion3)
 		info["openTypeNameRecords"] = [
 			dict(nameID=1, platformID=1, encodingID=1, languageID=1)
 		]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		## invalid values
 		info = dict(fontInfoVersion3)
@@ -448,35 +448,35 @@ class ReadFontInfoVersion3TestCase(unittest.TestCase):
 			dict(nameID="1", platformID=1, encodingID=1, languageID=1, string="Name Record.")
 		]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		info = dict(fontInfoVersion3)
 		info["openTypeNameRecords"] = [
 			dict(nameID=1, platformID="1", encodingID=1, languageID=1, string="Name Record.")
 		]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		info = dict(fontInfoVersion3)
 		info["openTypeNameRecords"] = [
 			dict(nameID=1, platformID=1, encodingID="1", languageID=1, string="Name Record.")
 		]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		info = dict(fontInfoVersion3)
 		info["openTypeNameRecords"] = [
 			dict(nameID=1, platformID=1, encodingID=1, languageID="1", string="Name Record.")
 		]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		info = dict(fontInfoVersion3)
 		info["openTypeNameRecords"] = [
 			dict(nameID=1, platformID=1, encodingID=1, languageID=1, string=1)
 		]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		## duplicate
 		info = dict(fontInfoVersion3)
@@ -485,7 +485,7 @@ class ReadFontInfoVersion3TestCase(unittest.TestCase):
 			dict(nameID=1, platformID=1, encodingID=1, languageID=1, string="Name Record.")
 		]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		reader.readInfo(TestInfoObject())
 
 	def testOS2Read(self):
@@ -494,226 +494,226 @@ class ReadFontInfoVersion3TestCase(unittest.TestCase):
 		info = dict(fontInfoVersion3)
 		info["openTypeOS2WidthClass"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		## out or range
 		info = dict(fontInfoVersion3)
 		info["openTypeOS2WidthClass"] = 15
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeOS2WeightClass
 		info = dict(fontInfoVersion3)
 		## not an int
 		info["openTypeOS2WeightClass"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		## out of range
 		info["openTypeOS2WeightClass"] = -50
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeOS2Selection
 		info = dict(fontInfoVersion3)
 		info["openTypeOS2Selection"] = [-1]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeOS2VendorID
 		info = dict(fontInfoVersion3)
 		info["openTypeOS2VendorID"] = 1234
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeOS2Panose
 		## not an int
 		info = dict(fontInfoVersion3)
 		info["openTypeOS2Panose"] = [0, 1, 2, 3, 4, 5, 6, 7, 8, str(9)]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		## negative
 		info = dict(fontInfoVersion3)
 		info["openTypeOS2Panose"] = [0, 1, 2, 3, 4, 5, 6, 7, 8, -9]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		## too few values
 		info = dict(fontInfoVersion3)
 		info["openTypeOS2Panose"] = [0, 1, 2, 3]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		## too many values
 		info = dict(fontInfoVersion3)
 		info["openTypeOS2Panose"] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeOS2FamilyClass
 		## not an int
 		info = dict(fontInfoVersion3)
 		info["openTypeOS2FamilyClass"] = [1, str(1)]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		## too few values
 		info = dict(fontInfoVersion3)
 		info["openTypeOS2FamilyClass"] = [1]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		## too many values
 		info = dict(fontInfoVersion3)
 		info["openTypeOS2FamilyClass"] = [1, 1, 1]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		## out of range
 		info = dict(fontInfoVersion3)
 		info["openTypeOS2FamilyClass"] = [1, 201]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeOS2UnicodeRanges
 		## not an int
 		info = dict(fontInfoVersion3)
 		info["openTypeOS2UnicodeRanges"] = ["0"]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		## out of range
 		info = dict(fontInfoVersion3)
 		info["openTypeOS2UnicodeRanges"] = [-1]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeOS2CodePageRanges
 		## not an int
 		info = dict(fontInfoVersion3)
 		info["openTypeOS2CodePageRanges"] = ["0"]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		## out of range
 		info = dict(fontInfoVersion3)
 		info["openTypeOS2CodePageRanges"] = [-1]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeOS2TypoAscender
 		info = dict(fontInfoVersion3)
 		info["openTypeOS2TypoAscender"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeOS2TypoDescender
 		info = dict(fontInfoVersion3)
 		info["openTypeOS2TypoDescender"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeOS2TypoLineGap
 		info = dict(fontInfoVersion3)
 		info["openTypeOS2TypoLineGap"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeOS2WinAscent
 		info = dict(fontInfoVersion3)
 		info["openTypeOS2WinAscent"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		info = dict(fontInfoVersion3)
 		info["openTypeOS2WinAscent"] = -1
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeOS2WinDescent
 		info = dict(fontInfoVersion3)
 		info["openTypeOS2WinDescent"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		info = dict(fontInfoVersion3)
 		info["openTypeOS2WinDescent"] = -1
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeOS2Type
 		## not an int
 		info = dict(fontInfoVersion3)
 		info["openTypeOS2Type"] = ["1"]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		## out of range
 		info = dict(fontInfoVersion3)
 		info["openTypeOS2Type"] = [-1]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeOS2SubscriptXSize
 		info = dict(fontInfoVersion3)
 		info["openTypeOS2SubscriptXSize"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeOS2SubscriptYSize
 		info = dict(fontInfoVersion3)
 		info["openTypeOS2SubscriptYSize"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeOS2SubscriptXOffset
 		info = dict(fontInfoVersion3)
 		info["openTypeOS2SubscriptXOffset"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeOS2SubscriptYOffset
 		info = dict(fontInfoVersion3)
 		info["openTypeOS2SubscriptYOffset"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeOS2SuperscriptXSize
 		info = dict(fontInfoVersion3)
 		info["openTypeOS2SuperscriptXSize"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeOS2SuperscriptYSize
 		info = dict(fontInfoVersion3)
 		info["openTypeOS2SuperscriptYSize"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeOS2SuperscriptXOffset
 		info = dict(fontInfoVersion3)
 		info["openTypeOS2SuperscriptXOffset"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeOS2SuperscriptYOffset
 		info = dict(fontInfoVersion3)
 		info["openTypeOS2SuperscriptYOffset"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeOS2StrikeoutSize
 		info = dict(fontInfoVersion3)
 		info["openTypeOS2StrikeoutSize"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeOS2StrikeoutPosition
 		info = dict(fontInfoVersion3)
 		info["openTypeOS2StrikeoutPosition"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 
 	def testVheaRead(self):
@@ -721,37 +721,37 @@ class ReadFontInfoVersion3TestCase(unittest.TestCase):
 		info = dict(fontInfoVersion3)
 		info["openTypeVheaVertTypoAscender"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeVheaVertTypoDescender
 		info = dict(fontInfoVersion3)
 		info["openTypeVheaVertTypoDescender"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeVheaVertTypoLineGap
 		info = dict(fontInfoVersion3)
 		info["openTypeVheaVertTypoLineGap"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeVheaCaretSlopeRise
 		info = dict(fontInfoVersion3)
 		info["openTypeVheaCaretSlopeRise"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeVheaCaretSlopeRun
 		info = dict(fontInfoVersion3)
 		info["openTypeVheaCaretSlopeRun"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# openTypeVheaCaretOffset
 		info = dict(fontInfoVersion3)
 		info["openTypeVheaCaretOffset"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 
 	def testFONDRead(self):
@@ -759,13 +759,13 @@ class ReadFontInfoVersion3TestCase(unittest.TestCase):
 		info = dict(fontInfoVersion3)
 		info["macintoshFONDFamilyID"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# macintoshFONDName
 		info = dict(fontInfoVersion3)
 		info["macintoshFONDName"] = 123
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 
 	def testPostscriptRead(self):
@@ -773,211 +773,211 @@ class ReadFontInfoVersion3TestCase(unittest.TestCase):
 		info = dict(fontInfoVersion3)
 		info["postscriptFontName"] = 123
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# postscriptFullName
 		info = dict(fontInfoVersion3)
 		info["postscriptFullName"] = 123
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# postscriptSlantAngle
 		info = dict(fontInfoVersion3)
 		info["postscriptSlantAngle"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, info=TestInfoObject())
 		# postscriptUniqueID
 		info = dict(fontInfoVersion3)
 		info["postscriptUniqueID"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		# postscriptUnderlineThickness
 		info = dict(fontInfoVersion3)
 		info["postscriptUnderlineThickness"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		# postscriptUnderlinePosition
 		info = dict(fontInfoVersion3)
 		info["postscriptUnderlinePosition"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		# postscriptIsFixedPitch
 		info = dict(fontInfoVersion3)
 		info["postscriptIsFixedPitch"] = 2
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		# postscriptBlueValues
 		## not a list
 		info = dict(fontInfoVersion3)
 		info["postscriptBlueValues"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## uneven value count
 		info = dict(fontInfoVersion3)
 		info["postscriptBlueValues"] = [500]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## too many values
 		info = dict(fontInfoVersion3)
 		info["postscriptBlueValues"] = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		# postscriptOtherBlues
 		## not a list
 		info = dict(fontInfoVersion3)
 		info["postscriptOtherBlues"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## uneven value count
 		info = dict(fontInfoVersion3)
 		info["postscriptOtherBlues"] = [500]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## too many values
 		info = dict(fontInfoVersion3)
 		info["postscriptOtherBlues"] = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		# postscriptFamilyBlues
 		## not a list
 		info = dict(fontInfoVersion3)
 		info["postscriptFamilyBlues"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## uneven value count
 		info = dict(fontInfoVersion3)
 		info["postscriptFamilyBlues"] = [500]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## too many values
 		info = dict(fontInfoVersion3)
 		info["postscriptFamilyBlues"] = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		# postscriptFamilyOtherBlues
 		## not a list
 		info = dict(fontInfoVersion3)
 		info["postscriptFamilyOtherBlues"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## uneven value count
 		info = dict(fontInfoVersion3)
 		info["postscriptFamilyOtherBlues"] = [500]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## too many values
 		info = dict(fontInfoVersion3)
 		info["postscriptFamilyOtherBlues"] = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		# postscriptStemSnapH
 		## not list
 		info = dict(fontInfoVersion3)
 		info["postscriptStemSnapH"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## too many values
 		info = dict(fontInfoVersion3)
 		info["postscriptStemSnapH"] = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		# postscriptStemSnapV
 		## not list
 		info = dict(fontInfoVersion3)
 		info["postscriptStemSnapV"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## too many values
 		info = dict(fontInfoVersion3)
 		info["postscriptStemSnapV"] = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		# postscriptBlueFuzz
 		info = dict(fontInfoVersion3)
 		info["postscriptBlueFuzz"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		# postscriptBlueShift
 		info = dict(fontInfoVersion3)
 		info["postscriptBlueShift"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		# postscriptBlueScale
 		info = dict(fontInfoVersion3)
 		info["postscriptBlueScale"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		# postscriptForceBold
 		info = dict(fontInfoVersion3)
 		info["postscriptForceBold"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		# postscriptDefaultWidthX
 		info = dict(fontInfoVersion3)
 		info["postscriptDefaultWidthX"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		# postscriptNominalWidthX
 		info = dict(fontInfoVersion3)
 		info["postscriptNominalWidthX"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		# postscriptWeightName
 		info = dict(fontInfoVersion3)
 		info["postscriptWeightName"] = 123
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		# postscriptDefaultCharacter
 		info = dict(fontInfoVersion3)
 		info["postscriptDefaultCharacter"] = 123
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		# postscriptWindowsCharacterSet
 		info = dict(fontInfoVersion3)
 		info["postscriptWindowsCharacterSet"] = -1
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		# macintoshFONDFamilyID
 		info = dict(fontInfoVersion3)
 		info["macintoshFONDFamilyID"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		# macintoshFONDName
 		info = dict(fontInfoVersion3)
 		info["macintoshFONDName"] = 123
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 
 	def testWOFFRead(self):
@@ -985,551 +985,551 @@ class ReadFontInfoVersion3TestCase(unittest.TestCase):
 		info = dict(fontInfoVersion3)
 		info["woffMajorVersion"] = 1.0
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		info = dict(fontInfoVersion3)
 		info["woffMajorVersion"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		# woffMinorVersion
 		info = dict(fontInfoVersion3)
 		info["woffMinorVersion"] = 1.0
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		info = dict(fontInfoVersion3)
 		info["woffMinorVersion"] = "abc"
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		# woffMetadataUniqueID
 		## none
 		info = dict(fontInfoVersion3)
 		del info["woffMetadataUniqueID"]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		reader.readInfo(TestInfoObject())
 		## not a dict
 		info = dict(fontInfoVersion3)
 		info["woffMetadataUniqueID"] = 1
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## unknown key
 		info = dict(fontInfoVersion3)
 		info["woffMetadataUniqueID"] = dict(id="foo", notTheRightKey=1)
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## no id
 		info = dict(fontInfoVersion3)
 		info["woffMetadataUniqueID"] = dict()
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## not a string for id
 		info = dict(fontInfoVersion3)
 		info["woffMetadataUniqueID"] = dict(id=1)
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## empty string
 		info = dict(fontInfoVersion3)
 		info["woffMetadataUniqueID"] = dict(id="")
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		reader.readInfo(TestInfoObject())
 		# woffMetadataVendor
 		## no name
 		info = dict(fontInfoVersion3)
 		info["woffMetadataVendor"] = dict(url="foo")
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## name not a string
 		info = dict(fontInfoVersion3)
 		info["woffMetadataVendor"] = dict(name=1, url="foo")
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## name an empty string
 		info = dict(fontInfoVersion3)
 		info["woffMetadataVendor"] = dict(name="", url="foo")
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		reader.readInfo(TestInfoObject())
 		## no URL
 		info = dict(fontInfoVersion3)
 		info["woffMetadataVendor"] = dict(name="foo")
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		reader.readInfo(TestInfoObject())
 		## url not a string
 		info = dict(fontInfoVersion3)
 		info["woffMetadataVendor"] = dict(name="foo", url=1)
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## url empty string
 		info = dict(fontInfoVersion3)
 		info["woffMetadataVendor"] = dict(name="foo", url="")
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		reader.readInfo(TestInfoObject())
 		## have dir
 		info = dict(fontInfoVersion3)
 		info["woffMetadataVendor"] = dict(name="foo", url="bar", dir="ltr")
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		reader.readInfo(TestInfoObject())
 		info = dict(fontInfoVersion3)
 		info["woffMetadataVendor"] = dict(name="foo", url="bar", dir="rtl")
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		reader.readInfo(TestInfoObject())
 		## dir not a string
 		info = dict(fontInfoVersion3)
 		info["woffMetadataVendor"] = dict(name="foo", url="bar", dir=1)
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## dir not ltr or rtl
 		info = dict(fontInfoVersion3)
 		info["woffMetadataVendor"] = dict(name="foo", url="bar", dir="utd")
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## have class
 		info = dict(fontInfoVersion3)
 		info["woffMetadataVendor"] = {"name"  : "foo", "url" : "bar", "class" : "hello"}
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		reader.readInfo(TestInfoObject())
 		## class not a string
 		info = dict(fontInfoVersion3)
 		info["woffMetadataVendor"] = {"name"  : "foo", "url" : "bar", "class" : 1}
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## class empty string
 		info = dict(fontInfoVersion3)
 		info["woffMetadataVendor"] = {"name"  : "foo", "url" : "bar", "class" : ""}
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		reader.readInfo(TestInfoObject())
 		# woffMetadataCredits
 		## no credits attribute
 		info = dict(fontInfoVersion3)
 		info["woffMetadataCredits"] = {}
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## unknown attribute
 		info = dict(fontInfoVersion3)
 		info["woffMetadataCredits"] = dict(credits=[dict(name="foo")], notTheRightKey=1)
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## not a list
 		info = dict(fontInfoVersion3)
 		info["woffMetadataCredits"] = dict(credits="abc")
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## no elements in credits
 		info = dict(fontInfoVersion3)
 		info["woffMetadataCredits"] = dict(credits=[])
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## credit not a dict
 		info = dict(fontInfoVersion3)
 		info["woffMetadataCredits"] = dict(credits=["abc"])
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## unknown key
 		info = dict(fontInfoVersion3)
 		info["woffMetadataCredits"] = dict(credits=[dict(name="foo", notTheRightKey=1)])
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## no name
 		info = dict(fontInfoVersion3)
 		info["woffMetadataCredits"] = dict(credits=[dict(url="foo")])
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## name not a string
 		info = dict(fontInfoVersion3)
 		info["woffMetadataCredits"] = dict(credits=[dict(name=1)])
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## url not a string
 		info = dict(fontInfoVersion3)
 		info["woffMetadataCredits"] = dict(credits=[dict(name="foo", url=1)])
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## role not a string
 		info = dict(fontInfoVersion3)
 		info["woffMetadataCredits"] = dict(credits=[dict(name="foo", role=1)])
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## dir not a string
 		info = dict(fontInfoVersion3)
 		info["woffMetadataCredits"] = dict(credits=[dict(name="foo", dir=1)])
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## dir not ltr or rtl
 		info = dict(fontInfoVersion3)
 		info["woffMetadataCredits"] = dict(credits=[dict(name="foo", dir="utd")])
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## class not a string
 		info = dict(fontInfoVersion3)
 		info["woffMetadataCredits"] = dict(credits=[{"name"  : "foo", "class" : 1}])
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		# woffMetadataDescription
 		## no url
 		info = dict(fontInfoVersion3)
 		info["woffMetadataDescription"] = dict(text=[dict(text="foo")])
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		reader.readInfo(TestInfoObject())
 		## url not a string
 		info = dict(fontInfoVersion3)
 		info["woffMetadataDescription"] = dict(text=[dict(text="foo")], url=1)
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## no text
 		info = dict(fontInfoVersion3)
 		info["woffMetadataDescription"] = dict(url="foo")
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## text not a list
 		info = dict(fontInfoVersion3)
 		info["woffMetadataDescription"] = dict(text="abc")
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## text item not a dict
 		info = dict(fontInfoVersion3)
 		info["woffMetadataDescription"] = dict(text=["abc"])
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## text item unknown key
 		info = dict(fontInfoVersion3)
 		info["woffMetadataDescription"] = dict(text=[dict(text="foo", notTheRightKey=1)])
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## text item missing text
 		info = dict(fontInfoVersion3)
 		info["woffMetadataDescription"] = dict(text=[dict(language="foo")])
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## text not a string
 		info = dict(fontInfoVersion3)
 		info["woffMetadataDescription"] = dict(text=[dict(text=1)])
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## url not a string
 		info = dict(fontInfoVersion3)
 		info["woffMetadataDescription"] = dict(text=[dict(text="foo", url=1)])
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## language not a string
 		info = dict(fontInfoVersion3)
 		info["woffMetadataDescription"] = dict(text=[dict(text="foo", language=1)])
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## dir not ltr or rtl
 		info = dict(fontInfoVersion3)
 		info["woffMetadataDescription"] = dict(text=[dict(text="foo", dir="utd")])
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## class not a string
 		info = dict(fontInfoVersion3)
 		info["woffMetadataDescription"] = dict(text=[{"text"  : "foo", "class" : 1}])
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		# woffMetadataLicense
 		## no url
 		info = dict(fontInfoVersion3)
 		info["woffMetadataLicense"] = dict(text=[dict(text="foo")])
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		reader.readInfo(TestInfoObject())
 		## url not a string
 		info = dict(fontInfoVersion3)
 		info["woffMetadataLicense"] = dict(text=[dict(text="foo")], url=1)
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## id not a string
 		info = dict(fontInfoVersion3)
 		info["woffMetadataLicense"] = dict(text=[dict(text="foo")], id=1)
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## no text
 		info = dict(fontInfoVersion3)
 		info["woffMetadataLicense"] = dict(url="foo")
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		reader.readInfo(TestInfoObject())
 		## text not a list
 		info = dict(fontInfoVersion3)
 		info["woffMetadataLicense"] = dict(text="abc")
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## text item not a dict
 		info = dict(fontInfoVersion3)
 		info["woffMetadataLicense"] = dict(text=["abc"])
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## text item unknown key
 		info = dict(fontInfoVersion3)
 		info["woffMetadataLicense"] = dict(text=[dict(text="foo", notTheRightKey=1)])
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## text item missing text
 		info = dict(fontInfoVersion3)
 		info["woffMetadataLicense"] = dict(text=[dict(language="foo")])
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## text not a string
 		info = dict(fontInfoVersion3)
 		info["woffMetadataLicense"] = dict(text=[dict(text=1)])
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## url not a string
 		info = dict(fontInfoVersion3)
 		info["woffMetadataLicense"] = dict(text=[dict(text="foo", url=1)])
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## language not a string
 		info = dict(fontInfoVersion3)
 		info["woffMetadataLicense"] = dict(text=[dict(text="foo", language=1)])
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## dir not ltr or rtl
 		info = dict(fontInfoVersion3)
 		info["woffMetadataLicense"] = dict(text=[dict(text="foo", dir="utd")])
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## class not a string
 		info = dict(fontInfoVersion3)
 		info["woffMetadataLicense"] = dict(text=[{"text"  : "foo", "class" : 1}])
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		# woffMetadataCopyright
 		## unknown attribute
 		info = dict(fontInfoVersion3)
 		info["woffMetadataCopyright"] = dict(text=[dict(text="foo")], notTheRightKey=1)
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## no text
 		info = dict(fontInfoVersion3)
 		info["woffMetadataCopyright"] = dict()
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## text not a list
 		info = dict(fontInfoVersion3)
 		info["woffMetadataCopyright"] = dict(text="abc")
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## text item not a dict
 		info = dict(fontInfoVersion3)
 		info["woffMetadataCopyright"] = dict(text=["abc"])
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## text item unknown key
 		info = dict(fontInfoVersion3)
 		info["woffMetadataCopyright"] = dict(text=[dict(text="foo", notTheRightKey=1)])
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## text item missing text
 		info = dict(fontInfoVersion3)
 		info["woffMetadataCopyright"] = dict(text=[dict(language="foo")])
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## text not a string
 		info = dict(fontInfoVersion3)
 		info["woffMetadataCopyright"] = dict(text=[dict(text=1)])
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## url not a string
 		info = dict(fontInfoVersion3)
 		info["woffMetadataCopyright"] = dict(text=[dict(text="foo", url=1)])
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## language not a string
 		info = dict(fontInfoVersion3)
 		info["woffMetadataCopyright"] = dict(text=[dict(text="foo", language=1)])
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## dir not ltr or rtl
 		info = dict(fontInfoVersion3)
 		info["woffMetadataCopyright"] = dict(text=[dict(text="foo", dir="utd")])
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## class not a string
 		info = dict(fontInfoVersion3)
 		info["woffMetadataCopyright"] = dict(text=[{"text"  : "foo", "class" : 1}])
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		# woffMetadataTrademark
 		## unknown attribute
 		info = dict(fontInfoVersion3)
 		info["woffMetadataTrademark"] = dict(text=[dict(text="foo")], notTheRightKey=1)
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## no text
 		info = dict(fontInfoVersion3)
 		info["woffMetadataTrademark"] = dict()
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## text not a list
 		info = dict(fontInfoVersion3)
 		info["woffMetadataTrademark"] = dict(text="abc")
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## text item not a dict
 		info = dict(fontInfoVersion3)
 		info["woffMetadataTrademark"] = dict(text=["abc"])
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## text item unknown key
 		info = dict(fontInfoVersion3)
 		info["woffMetadataTrademark"] = dict(text=[dict(text="foo", notTheRightKey=1)])
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## text item missing text
 		info = dict(fontInfoVersion3)
 		info["woffMetadataTrademark"] = dict(text=[dict(language="foo")])
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## text not a string
 		info = dict(fontInfoVersion3)
 		info["woffMetadataTrademark"] = dict(text=[dict(text=1)])
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## url not a string
 		info = dict(fontInfoVersion3)
 		info["woffMetadataTrademark"] = dict(text=[dict(text="foo", url=1)])
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## language not a string
 		info = dict(fontInfoVersion3)
 		info["woffMetadataTrademark"] = dict(text=[dict(text="foo", language=1)])
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## dir not ltr or rtl
 		info = dict(fontInfoVersion3)
 		info["woffMetadataTrademark"] = dict(text=[dict(text="foo", dir="utd")])
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## class not a string
 		info = dict(fontInfoVersion3)
 		info["woffMetadataTrademark"] = dict(text=[{"text"  : "foo", "class" : 1}])
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		# woffMetadataLicensee
 		## no name
 		info = dict(fontInfoVersion3)
 		info["woffMetadataLicensee"] = dict()
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## unknown attribute
 		info = dict(fontInfoVersion3)
 		info["woffMetadataLicensee"] = dict(name="foo", notTheRightKey=1)
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## name not a string
 		info = dict(fontInfoVersion3)
 		info["woffMetadataLicensee"] = dict(name=1)
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## dir options
 		info = dict(fontInfoVersion3)
 		info["woffMetadataLicensee"] = dict(name="foo", dir="ltr")
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		reader.readInfo(TestInfoObject())
 		info = dict(fontInfoVersion3)
 		info["woffMetadataLicensee"] = dict(name="foo", dir="rtl")
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		reader.readInfo(TestInfoObject())
 		## dir not ltr or rtl
 		info = dict(fontInfoVersion3)
 		info["woffMetadataLicensee"] = dict(name="foo", dir="utd")
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## have class
 		info = dict(fontInfoVersion3)
 		info["woffMetadataLicensee"] = {"name" : "foo", "class" : "hello"}
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		reader.readInfo(TestInfoObject())
 		## class not a string
 		info = dict(fontInfoVersion3)
 		info["woffMetadataLicensee"] = {"name" : "foo", "class" : 1}
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 
 	def testGuidelinesRead(self):
@@ -1538,159 +1538,159 @@ class ReadFontInfoVersion3TestCase(unittest.TestCase):
 		info = dict(fontInfoVersion3)
 		info["guidelines"] = [dict(x="1")]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		# y
 		## not an int or float
 		info = dict(fontInfoVersion3)
 		info["guidelines"] = [dict(y="1")]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		# angle
 		## < 0
 		info = dict(fontInfoVersion3)
 		info["guidelines"] = [dict(x=0, y=0, angle=-1)]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## > 360
 		info = dict(fontInfoVersion3)
 		info["guidelines"] = [dict(x=0, y=0, angle=361)]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		# name
 		## not a string
 		info = dict(fontInfoVersion3)
 		info["guidelines"] = [dict(x=0, name=1)]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		# color
 		## not a string
 		info = dict(fontInfoVersion3)
 		info["guidelines"] = [dict(x=0, color=1)]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## not enough commas
 		info = dict(fontInfoVersion3)
 		info["guidelines"] = [dict(x=0, color="1 0, 0, 0")]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		info = dict(fontInfoVersion3)
 		info["guidelines"] = [dict(x=0, color="1 0 0, 0")]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		info = dict(fontInfoVersion3)
 		info["guidelines"] = [dict(x=0, color="1 0 0 0")]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## not enough parts
 		info = dict(fontInfoVersion3)
 		info["guidelines"] = [dict(x=0, color=", 0, 0, 0")]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		info = dict(fontInfoVersion3)
 		info["guidelines"] = [dict(x=0, color="1, , 0, 0")]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		info = dict(fontInfoVersion3)
 		info["guidelines"] = [dict(x=0, color="1, 0, , 0")]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		info = dict(fontInfoVersion3)
 		info["guidelines"] = [dict(x=0, color="1, 0, 0, ")]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		info = dict(fontInfoVersion3)
 		info["guidelines"] = [dict(x=0, color=", , , ")]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## not a number in all positions
 		info = dict(fontInfoVersion3)
 		info["guidelines"] = [dict(x=0, color="r, 1, 1, 1")]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		info = dict(fontInfoVersion3)
 		info["guidelines"] = [dict(x=0, color="1, g, 1, 1")]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		info = dict(fontInfoVersion3)
 		info["guidelines"] = [dict(x=0, color="1, 1, b, 1")]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		info = dict(fontInfoVersion3)
 		info["guidelines"] = [dict(x=0, color="1, 1, 1, a")]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## too many parts
 		info = dict(fontInfoVersion3)
 		info["guidelines"] = [dict(x=0, color="1, 0, 0, 0, 0")]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## < 0 in each position
 		info = dict(fontInfoVersion3)
 		info["guidelines"] = [dict(x=0, color="-1, 0, 0, 0")]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		info = dict(fontInfoVersion3)
 		info["guidelines"] = [dict(x=0, color="0, -1, 0, 0")]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		info = dict(fontInfoVersion3)
 		info["guidelines"] = [dict(x=0, color="0, 0, -1, 0")]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		info = dict(fontInfoVersion3)
 		info["guidelines"] = [dict(x=0, color="0, 0, 0, -1")]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		## > 1 in each position
 		info = dict(fontInfoVersion3)
 		info["guidelines"] = [dict(x=0, color="2, 0, 0, 0")]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		info = dict(fontInfoVersion3)
 		info["guidelines"] = [dict(x=0, color="0, 2, 0, 0")]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		info = dict(fontInfoVersion3)
 		info["guidelines"] = [dict(x=0, color="0, 0, 2, 0")]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		info = dict(fontInfoVersion3)
 		info["guidelines"] = [dict(x=0, color="0, 0, 0, 2")]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 		# identifier
 		## duplicate
 		info = dict(fontInfoVersion3)
 		info["guidelines"] = [dict(x=0, identifier="guide1"), dict(y=0, identifier="guide1")]
 		self._writeInfoToPlist(info)
-		reader = UFOReader(self.dstDir)
+		reader = UFOReader(self.dstDir, validate=True)
 		self.assertRaises(UFOLibError, reader.readInfo, TestInfoObject())
 
 
@@ -3418,18 +3418,18 @@ class UFO3ReadLayersTestCase(unittest.TestCase):
 			metaInfo=dict(creator="test", formatVersion=1),
 			layerContents=dict()
 		)
-		reader = UFOReader(self.ufoPath)
+		reader = UFOReader(self.ufoPath, validate=True)
 		reader.getGlyphSet()
 		# UFO 2
 		self.makeUFO(
 			metaInfo=dict(creator="test", formatVersion=2),
 			layerContents=dict()
 		)
-		reader = UFOReader(self.ufoPath)
+		reader = UFOReader(self.ufoPath, validate=True)
 		reader.getGlyphSet()
 		# UFO 3
 		self.makeUFO()
-		reader = UFOReader(self.ufoPath)
+		reader = UFOReader(self.ufoPath, validate=True)
 		reader.getGlyphSet()
 
 	# missing layer contents
@@ -3438,7 +3438,7 @@ class UFO3ReadLayersTestCase(unittest.TestCase):
 		self.makeUFO()
 		path = os.path.join(self.ufoPath, "layercontents.plist")
 		os.remove(path)
-		reader = UFOReader(self.ufoPath)
+		reader = UFOReader(self.ufoPath, validate=True)
 		self.assertRaises(UFOLibError, reader.getGlyphSet)
 
 	# layer contents invalid format
@@ -3450,7 +3450,7 @@ class UFO3ReadLayersTestCase(unittest.TestCase):
 		os.remove(path)
 		with open(path, "w") as f:
 			f.write("test")
-		reader = UFOReader(self.ufoPath)
+		reader = UFOReader(self.ufoPath, validate=True)
 		self.assertRaises(UFOLibError, reader.getGlyphSet)
 		# dict
 		self.makeUFO()
@@ -3463,7 +3463,7 @@ class UFO3ReadLayersTestCase(unittest.TestCase):
 		}
 		with open(path, "wb") as f:
 			writePlist(layerContents, f)
-		reader = UFOReader(self.ufoPath)
+		reader = UFOReader(self.ufoPath, validate=True)
 		self.assertRaises(UFOLibError, reader.getGlyphSet)
 
 	# layer contents invalid name format
@@ -3479,7 +3479,7 @@ class UFO3ReadLayersTestCase(unittest.TestCase):
 		]
 		with open(path, "wb") as f:
 			writePlist(layerContents, f)
-		reader = UFOReader(self.ufoPath)
+		reader = UFOReader(self.ufoPath, validate=True)
 		self.assertRaises(UFOLibError, reader.getGlyphSet)
 
 	# layer contents invalid directory format
@@ -3495,7 +3495,7 @@ class UFO3ReadLayersTestCase(unittest.TestCase):
 		]
 		with open(path, "wb") as f:
 			writePlist(layerContents, f)
-		reader = UFOReader(self.ufoPath)
+		reader = UFOReader(self.ufoPath, validate=True)
 		self.assertRaises(UFOLibError, reader.getGlyphSet)
 
 	# directory listed in contents not on disk
@@ -3511,7 +3511,7 @@ class UFO3ReadLayersTestCase(unittest.TestCase):
 		]
 		with open(path, "wb") as f:
 			writePlist(layerContents, f)
-		reader = UFOReader(self.ufoPath)
+		reader = UFOReader(self.ufoPath, validate=True)
 		self.assertRaises(UFOLibError, reader.getGlyphSet)
 
 	# # directory on disk not listed in contents
@@ -3527,7 +3527,7 @@ class UFO3ReadLayersTestCase(unittest.TestCase):
 	# 	]
 	# 	with open(path, "wb") as f:
 	# 		writePlist(layerContents, f)
-	# 	reader = UFOReader(self.ufoPath)
+	# 	reader = UFOReader(self.ufoPath, validate=True)
 	# 	with self.assertRaises(UFOLibError):
 	# 		reader.getGlyphSet()
 
@@ -3543,7 +3543,7 @@ class UFO3ReadLayersTestCase(unittest.TestCase):
 		]
 		with open(path, "wb") as f:
 			writePlist(layerContents, f)
-		reader = UFOReader(self.ufoPath)
+		reader = UFOReader(self.ufoPath, validate=True)
 		self.assertRaises(UFOLibError, reader.getGlyphSet)
 
 	# duplicate layer name
@@ -3559,7 +3559,7 @@ class UFO3ReadLayersTestCase(unittest.TestCase):
 		]
 		with open(path, "wb") as f:
 			writePlist(layerContents, f)
-		reader = UFOReader(self.ufoPath)
+		reader = UFOReader(self.ufoPath, validate=True)
 		self.assertRaises(UFOLibError, reader.getGlyphSet)
 
 	# directory referenced by two layer names
@@ -3575,7 +3575,7 @@ class UFO3ReadLayersTestCase(unittest.TestCase):
 		]
 		with open(path, "wb") as f:
 			writePlist(layerContents, f)
-		reader = UFOReader(self.ufoPath)
+		reader = UFOReader(self.ufoPath, validate=True)
 		self.assertRaises(UFOLibError, reader.getGlyphSet)
 
 	# default without a name
@@ -3592,7 +3592,7 @@ class UFO3ReadLayersTestCase(unittest.TestCase):
 		]
 		with open(path, "wb") as f:
 			writePlist(layerContents, f)
-		reader = UFOReader(self.ufoPath)
+		reader = UFOReader(self.ufoPath, validate=True)
 		reader.getGlyphSet()
 
 	# default with a name
@@ -3610,7 +3610,7 @@ class UFO3ReadLayersTestCase(unittest.TestCase):
 		expected = layerContents[0][0]
 		with open(path, "wb") as f:
 			writePlist(layerContents, f)
-		reader = UFOReader(self.ufoPath)
+		reader = UFOReader(self.ufoPath, validate=True)
 		result = reader.getDefaultLayerName()
 		self.assertEqual(expected, result)
 		# get the glyph set
@@ -3624,7 +3624,7 @@ class UFO3ReadLayersTestCase(unittest.TestCase):
 		]
 		with open(path, "wb") as f:
 			writePlist(layerContents, f)
-		reader = UFOReader(self.ufoPath)
+		reader = UFOReader(self.ufoPath, validate=True)
 		reader.getGlyphSet(expected)
 
 	# layer order
@@ -3641,7 +3641,7 @@ class UFO3ReadLayersTestCase(unittest.TestCase):
 		expected = [name for (name, directory) in layerContents]
 		with open(path, "wb") as f:
 			writePlist(layerContents, f)
-		reader = UFOReader(self.ufoPath)
+		reader = UFOReader(self.ufoPath, validate=True)
 		result = reader.getLayerNames()
 		self.assertEqual(expected, result)
 		self.makeUFO()
@@ -3655,7 +3655,7 @@ class UFO3ReadLayersTestCase(unittest.TestCase):
 		expected = [name for (name, directory) in layerContents]
 		with open(path, "wb") as f:
 			writePlist(layerContents, f)
-		reader = UFOReader(self.ufoPath)
+		reader = UFOReader(self.ufoPath, validate=True)
 		result = reader.getLayerNames()
 		self.assertEqual(expected, result)
 		self.makeUFO()
@@ -3669,7 +3669,7 @@ class UFO3ReadLayersTestCase(unittest.TestCase):
 		expected = [name for (name, directory) in layerContents]
 		with open(path, "wb") as f:
 			writePlist(layerContents, f)
-		reader = UFOReader(self.ufoPath)
+		reader = UFOReader(self.ufoPath, validate=True)
 		result = reader.getLayerNames()
 		self.assertEqual(expected, result)
 
@@ -4071,7 +4071,7 @@ class UFO3WriteLayersTestCase(unittest.TestCase):
 
 	# rename unknown layer
 
-	def testRenameLayerDuplicateName(self):
+	def testRenameLayerUnknownName(self):
 		self.makeUFO()
 		writer = UFOWriter(self.ufoPath)
 		self.assertRaises(UFOLibError, writer.renameGlyphSet, "does not exist", "layer 2")
@@ -4343,7 +4343,7 @@ class UFO3ReadLayerInfoTestCase(unittest.TestCase):
 
 	def testValidLayerInfo(self):
 		self.makeUFO()
-		reader = UFOReader(self.ufoPath)
+		reader = UFOReader(self.ufoPath, validate=True)
 		glyphSet = reader.getGlyphSet()
 		info = TestLayerInfoObject()
 		glyphSet.readLayerInfo(info)
@@ -4357,7 +4357,7 @@ class UFO3ReadLayerInfoTestCase(unittest.TestCase):
 		path = os.path.join(self.ufoPath, "glyphs", "layerinfo.plist")
 		os.remove(path)
 		# read
-		reader = UFOReader(self.ufoPath)
+		reader = UFOReader(self.ufoPath, validate=True)
 		glyphSet = reader.getGlyphSet()
 		info = TestLayerInfoObject()
 		glyphSet.readLayerInfo(info)
@@ -4372,7 +4372,7 @@ class UFO3ReadLayerInfoTestCase(unittest.TestCase):
 		with open(path, "w") as f:
 			f.write("test")
 		# read
-		reader = UFOReader(self.ufoPath)
+		reader = UFOReader(self.ufoPath, validate=True)
 		glyphSet = reader.getGlyphSet()
 		info = TestLayerInfoObject()
 		self.assertRaises(GlifLibError, glyphSet.readLayerInfo, info)
@@ -4384,7 +4384,7 @@ class UFO3ReadLayerInfoTestCase(unittest.TestCase):
 		with open(path, "wb") as f:
 			writePlist(info, f)
 		# read
-		reader = UFOReader(self.ufoPath)
+		reader = UFOReader(self.ufoPath, validate=True)
 		glyphSet = reader.getGlyphSet()
 		info = TestLayerInfoObject()
 		self.assertRaises(GlifLibError, glyphSet.readLayerInfo, info)
@@ -4394,139 +4394,139 @@ class UFO3ReadLayerInfoTestCase(unittest.TestCase):
 		info = {}
 		info["color"] = 1
 		self.makeUFO(layerInfo=info)
-		reader = UFOReader(self.ufoPath)
+		reader = UFOReader(self.ufoPath, validate=True)
 		glyphSet = reader.getGlyphSet()
 		self.assertRaises(GlifLibError, glyphSet.readLayerInfo, TestLayerInfoObject())
 		## not enough commas
 		info = {}
 		info["color"] = "1 0, 0, 0"
 		self.makeUFO(layerInfo=info)
-		reader = UFOReader(self.ufoPath)
+		reader = UFOReader(self.ufoPath, validate=True)
 		glyphSet = reader.getGlyphSet()
 		self.assertRaises(GlifLibError, glyphSet.readLayerInfo, TestLayerInfoObject())
 		info = {}
 		info["color"] = "1 0 0, 0"
 		self.makeUFO(layerInfo=info)
-		reader = UFOReader(self.ufoPath)
+		reader = UFOReader(self.ufoPath, validate=True)
 		glyphSet = reader.getGlyphSet()
 		self.assertRaises(GlifLibError, glyphSet.readLayerInfo, TestLayerInfoObject())
 		info = {}
 		info["color"] = "1 0 0 0"
 		self.makeUFO(layerInfo=info)
-		reader = UFOReader(self.ufoPath)
+		reader = UFOReader(self.ufoPath, validate=True)
 		glyphSet = reader.getGlyphSet()
 		self.assertRaises(GlifLibError, glyphSet.readLayerInfo, TestLayerInfoObject())
 		## not enough parts
 		info = {}
 		info["color"] = ", 0, 0, 0"
 		self.makeUFO(layerInfo=info)
-		reader = UFOReader(self.ufoPath)
+		reader = UFOReader(self.ufoPath, validate=True)
 		glyphSet = reader.getGlyphSet()
 		self.assertRaises(GlifLibError, glyphSet.readLayerInfo, TestLayerInfoObject())
 		info = {}
 		info["color"] = "1, , 0, 0"
 		self.makeUFO(layerInfo=info)
-		reader = UFOReader(self.ufoPath)
+		reader = UFOReader(self.ufoPath, validate=True)
 		glyphSet = reader.getGlyphSet()
 		self.assertRaises(GlifLibError, glyphSet.readLayerInfo, TestLayerInfoObject())
 		info = {}
 		info["color"] = "1, 0, , 0"
 		self.makeUFO(layerInfo=info)
-		reader = UFOReader(self.ufoPath)
+		reader = UFOReader(self.ufoPath, validate=True)
 		glyphSet = reader.getGlyphSet()
 		self.assertRaises(GlifLibError, glyphSet.readLayerInfo, TestLayerInfoObject())
 		info = {}
 		info["color"] = "1, 0, 0, "
 		self.makeUFO(layerInfo=info)
-		reader = UFOReader(self.ufoPath)
+		reader = UFOReader(self.ufoPath, validate=True)
 		glyphSet = reader.getGlyphSet()
 		self.assertRaises(GlifLibError, glyphSet.readLayerInfo, TestLayerInfoObject())
 		info = {}
 		info["color"] = ", , , "
 		self.makeUFO(layerInfo=info)
-		reader = UFOReader(self.ufoPath)
+		reader = UFOReader(self.ufoPath, validate=True)
 		glyphSet = reader.getGlyphSet()
 		self.assertRaises(GlifLibError, glyphSet.readLayerInfo, TestLayerInfoObject())
 		## not a number in all positions
 		info = {}
 		info["color"] = "r, 1, 1, 1"
 		self.makeUFO(layerInfo=info)
-		reader = UFOReader(self.ufoPath)
+		reader = UFOReader(self.ufoPath, validate=True)
 		glyphSet = reader.getGlyphSet()
 		self.assertRaises(GlifLibError, glyphSet.readLayerInfo, TestLayerInfoObject())
 		info = {}
 		info["color"] = "1, g, 1, 1"
 		self.makeUFO(layerInfo=info)
-		reader = UFOReader(self.ufoPath)
+		reader = UFOReader(self.ufoPath, validate=True)
 		glyphSet = reader.getGlyphSet()
 		self.assertRaises(GlifLibError, glyphSet.readLayerInfo, TestLayerInfoObject())
 		info = {}
 		info["color"] = "1, 1, b, 1"
 		self.makeUFO(layerInfo=info)
-		reader = UFOReader(self.ufoPath)
+		reader = UFOReader(self.ufoPath, validate=True)
 		glyphSet = reader.getGlyphSet()
 		self.assertRaises(GlifLibError, glyphSet.readLayerInfo, TestLayerInfoObject())
 		info = {}
 		info["color"] = "1, 1, 1, a"
 		self.makeUFO(layerInfo=info)
-		reader = UFOReader(self.ufoPath)
+		reader = UFOReader(self.ufoPath, validate=True)
 		glyphSet = reader.getGlyphSet()
 		self.assertRaises(GlifLibError, glyphSet.readLayerInfo, TestLayerInfoObject())
 		## too many parts
 		info = {}
 		info["color"] = "1, 0, 0, 0, 0"
 		self.makeUFO(layerInfo=info)
-		reader = UFOReader(self.ufoPath)
+		reader = UFOReader(self.ufoPath, validate=True)
 		glyphSet = reader.getGlyphSet()
 		self.assertRaises(GlifLibError, glyphSet.readLayerInfo, TestLayerInfoObject())
 		## < 0 in each position
 		info = {}
 		info["color"] = "-1, 0, 0, 0"
 		self.makeUFO(layerInfo=info)
-		reader = UFOReader(self.ufoPath)
+		reader = UFOReader(self.ufoPath, validate=True)
 		glyphSet = reader.getGlyphSet()
 		self.assertRaises(GlifLibError, glyphSet.readLayerInfo, TestLayerInfoObject())
 		info = {}
 		info["color"] = "0, -1, 0, 0"
 		self.makeUFO(layerInfo=info)
-		reader = UFOReader(self.ufoPath)
+		reader = UFOReader(self.ufoPath, validate=True)
 		glyphSet = reader.getGlyphSet()
 		self.assertRaises(GlifLibError, glyphSet.readLayerInfo, TestLayerInfoObject())
 		info = {}
 		info["color"] = "0, 0, -1, 0"
 		self.makeUFO(layerInfo=info)
-		reader = UFOReader(self.ufoPath)
+		reader = UFOReader(self.ufoPath, validate=True)
 		glyphSet = reader.getGlyphSet()
 		self.assertRaises(GlifLibError, glyphSet.readLayerInfo, TestLayerInfoObject())
 		info = {}
 		info["color"] = "0, 0, 0, -1"
 		self.makeUFO(layerInfo=info)
-		reader = UFOReader(self.ufoPath)
+		reader = UFOReader(self.ufoPath, validate=True)
 		glyphSet = reader.getGlyphSet()
 		self.assertRaises(GlifLibError, glyphSet.readLayerInfo, TestLayerInfoObject())
 		## > 1 in each position
 		info = {}
 		info["color"] = "2, 0, 0, 0"
 		self.makeUFO(layerInfo=info)
-		reader = UFOReader(self.ufoPath)
+		reader = UFOReader(self.ufoPath, validate=True)
 		glyphSet = reader.getGlyphSet()
 		self.assertRaises(GlifLibError, glyphSet.readLayerInfo, TestLayerInfoObject())
 		info = {}
 		info["color"] = "0, 2, 0, 0"
 		self.makeUFO(layerInfo=info)
-		reader = UFOReader(self.ufoPath)
+		reader = UFOReader(self.ufoPath, validate=True)
 		glyphSet = reader.getGlyphSet()
 		self.assertRaises(GlifLibError, glyphSet.readLayerInfo, TestLayerInfoObject())
 		info = {}
 		info["color"] = "0, 0, 2, 0"
 		self.makeUFO(layerInfo=info)
-		reader = UFOReader(self.ufoPath)
+		reader = UFOReader(self.ufoPath, validate=True)
 		glyphSet = reader.getGlyphSet()
 		self.assertRaises(GlifLibError, glyphSet.readLayerInfo, TestLayerInfoObject())
 		info = {}
 		info["color"] = "0, 0, 0, 2"
 		self.makeUFO(layerInfo=info)
-		reader = UFOReader(self.ufoPath)
+		reader = UFOReader(self.ufoPath, validate=True)
 		glyphSet = reader.getGlyphSet()
 		self.assertRaises(GlifLibError, glyphSet.readLayerInfo, TestLayerInfoObject())
 

--- a/Lib/ufoLib/test/test_UFOConversion.py
+++ b/Lib/ufoLib/test/test_UFOConversion.py
@@ -224,7 +224,7 @@ class KerningUpConversionTestCase(unittest.TestCase):
 
 	def testUFO1(self):
 		self.makeUFO(formatVersion=2)
-		reader = UFOReader(self.ufoPath)
+		reader = UFOReader(self.ufoPath, validate=True)
 		kerning = reader.readKerning()
 		self.assertEqual(self.expectedKerning, kerning)
 		groups = reader.readGroups()
@@ -234,7 +234,7 @@ class KerningUpConversionTestCase(unittest.TestCase):
 
 	def testUFO2(self):
 		self.makeUFO(formatVersion=2)
-		reader = UFOReader(self.ufoPath)
+		reader = UFOReader(self.ufoPath, validate=True)
 		kerning = reader.readKerning()
 		self.assertEqual(self.expectedKerning, kerning)
 		groups = reader.readGroups()

--- a/Lib/ufoLib/test/test_glifLib.py
+++ b/Lib/ufoLib/test/test_glifLib.py
@@ -23,8 +23,8 @@ class GlyphSetTests(unittest.TestCase):
 		import difflib
 		srcDir = GLYPHSETDIR
 		dstDir = self.dstDir
-		src = GlyphSet(srcDir, ufoFormatVersion=2)
-		dst = GlyphSet(dstDir, ufoFormatVersion=2)
+		src = GlyphSet(srcDir, ufoFormatVersion=2, validateRead=True, validateWrite=True)
+		dst = GlyphSet(dstDir, ufoFormatVersion=2, validateRead=True, validateWrite=True)
 		for glyphName in src.keys():
 			g = src[glyphName]
 			g.drawPoints(None)  # load attrs
@@ -49,13 +49,13 @@ class GlyphSetTests(unittest.TestCase):
 				"%s.glif file differs after round tripping" % glyphName)
 
 	def testRebuildContents(self):
-		gset = GlyphSet(GLYPHSETDIR)
+		gset = GlyphSet(GLYPHSETDIR, validateRead=True, validateWrite=True)
 		contents = gset.contents
 		gset.rebuildContents()
 		self.assertEqual(contents, gset.contents)
 
 	def testReverseContents(self):
-		gset = GlyphSet(GLYPHSETDIR)
+		gset = GlyphSet(GLYPHSETDIR, validateRead=True, validateWrite=True)
 		d = {}
 		for k, v in gset.getReverseContents().items():
 			d[v] = k
@@ -65,8 +65,8 @@ class GlyphSetTests(unittest.TestCase):
 		self.assertEqual(d, org)
 
 	def testReverseContents2(self):
-		src = GlyphSet(GLYPHSETDIR)
-		dst = GlyphSet(self.dstDir)
+		src = GlyphSet(GLYPHSETDIR, validateRead=True, validateWrite=True)
+		dst = GlyphSet(self.dstDir, validateRead=True, validateWrite=True)
 		dstMap = dst.getReverseContents()
 		self.assertEqual(dstMap, {})
 		for glyphName in src.keys():
@@ -83,8 +83,8 @@ class GlyphSetTests(unittest.TestCase):
 	def testCustomFileNamingScheme(self):
 		def myGlyphNameToFileName(glyphName, glyphSet):
 			return "prefix" + glyphNameToFileName(glyphName, glyphSet)
-		src = GlyphSet(GLYPHSETDIR)
-		dst = GlyphSet(self.dstDir, myGlyphNameToFileName)
+		src = GlyphSet(GLYPHSETDIR, validateRead=True, validateWrite=True)
+		dst = GlyphSet(self.dstDir, myGlyphNameToFileName, validateRead=True, validateWrite=True)
 		for glyphName in src.keys():
 			g = src[glyphName]
 			g.drawPoints(None)  # load attrs
@@ -95,7 +95,7 @@ class GlyphSetTests(unittest.TestCase):
 		self.assertEqual(d, dst.contents)
 
 	def testGetUnicodes(self):
-		src = GlyphSet(GLYPHSETDIR)
+		src = GlyphSet(GLYPHSETDIR, validateRead=True, validateWrite=True)
 		unicodes = src.getUnicodes()
 		for glyphName in src.keys():
 			g = src[glyphName]


### PR DESCRIPTION
A pass at making the validation optional for ufoLib. No speedup testing has been done with this yet. Read is set to have validation off by default, Write is set to have it on by default. One can turn on/off validation on each method as wanted, or just set the global class option and let it be. 

There is one thing I couldn't untangle, the `_validateAndMassagePointStructures` method. It does things that are needed, and it does validation. Where one starts and the other ends, I wasn't 100% on, so I left this alone for now.