### PR TITLE
WIP: make lxml (and singledispatch) optional

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,5 @@
+comment: false
+coverage:
+    status:
+        project: off
+        patch: off

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,38 @@
+[run]
+# measure 'branch' coverage in addition to 'statement' coverage
+# See: http://coverage.readthedocs.io/en/coverage-4.5.1/branch.html
+branch = True
+
+# list of directories or packages to measure
+source = ufoLib
+
+# these are treated as equivalent when combining data
+[paths]
+source =
+    Lib/ufoLib
+    .tox/*/lib/python*/site-packages/ufoLib
+    .tox/*/Lib/site-packages/ufoLib
+    .tox/pypy*/site-packages/ufoLib
+
+[report]
+# Regexes for lines to exclude from consideration
+exclude_lines =
+    # keywords to use in inline comments to skip coverage
+    pragma: no cover
+
+    # don't complain if tests don't hit defensive assertion code
+    raise AssertionError
+    raise NotImplementedError
+
+    # don't complain if non-runnable code isn't run
+    if 0:
+    if __name__ == .__main__.:
+
+# Don't include files that are 100% covered
+skip_covered = True
+
+# ignore source code that can’t be found
+ignore_errors = True
+
+# when running a summary report, show missing lines
+show_missing = True

--- a/.coveragerc
+++ b/.coveragerc
@@ -33,6 +33,3 @@ skip_covered = True
 
 # ignore source code that can’t be found
 ignore_errors = True
-
-# when running a summary report, show missing lines
-show_missing = True

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ dist/
 .eggs/
 .tox/
 /.pytest_cache
+htmlcov/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,23 @@
 language: python
 sudo: false
-python:
-  - "2.7"
-  - "3.5"
-  - "3.6"
+matrix:
+  include:
+  - env: TOXENV=py27-cov,py27-cov-lxml
+    python: 2.7
+  - env: TOXENV=py36-cov,py36-cov-lxml
+    python: 3.6
+  - env: TOXENV=py37-cov,py37-cov-lxml
+    python: 3.7
+    dist: xenial
+    sudo: true
 install:
-  - pip install --upgrade pip setuptools wheel
-  - pip install tox-travis
+  - pip install tox
 script: tox
+after_success:
+  # upload code coverage to Codecov.io
+  - tox -e codecov
 before_deploy:
-  - pip wheel --no-deps -w dist .
-  - python setup.py sdist
+  - tox -e wheel
   - export WHL=$(ls dist/ufoLib*.whl)
   - export ZIP=$(ls dist/ufoLib*.zip)
 deploy:

--- a/Lib/ufoLib/__init__.py
+++ b/Lib/ufoLib/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, unicode_literals
 import os
 import shutil
 from io import StringIO, BytesIO, open

--- a/Lib/ufoLib/__init__.py
+++ b/Lib/ufoLib/__init__.py
@@ -3,7 +3,7 @@ import os
 import shutil
 from io import StringIO, BytesIO, open
 from copy import deepcopy
-from fontTools.misc.py23 import basestring, unicode
+from fontTools.misc.py23 import basestring, unicode, tounicode
 from ufoLib.glifLib import GlyphSet
 from ufoLib.validators import *
 from ufoLib.filenames import userNameToFileName
@@ -1109,6 +1109,8 @@ class UFOWriter(object):
 			for layerName in layerOrder:
 				if layerName is None:
 					layerName = DEFAULT_LAYER_NAME
+				else:
+					layerName = tounicode(layerName)
 				newOrder.append(layerName)
 			layerOrder = newOrder
 		else:

--- a/Lib/ufoLib/__init__.py
+++ b/Lib/ufoLib/__init__.py
@@ -1382,9 +1382,9 @@ def writeDataFileAtomically(data, path):
 		f.close()
 		if data == oldData:
 			return
-			# if the data is empty, remove the existing file
-			if not data:
-				os.remove(path)
+		# if the data is empty, remove the existing file
+		if not data:
+			os.remove(path)
 	if data:
 		f = open(path, "wb")
 		f.write(data)

--- a/Lib/ufoLib/converters.py
+++ b/Lib/ufoLib/converters.py
@@ -2,6 +2,9 @@
 Conversion functions.
 """
 
+from __future__ import absolute_import, unicode_literals
+
+
 # adapted from the UFO spec
 
 def convertUFO1OrUFO2KerningToUFO3Kerning(kerning, groups):

--- a/Lib/ufoLib/etree.py
+++ b/Lib/ufoLib/etree.py
@@ -224,12 +224,21 @@ except ImportError:
     import re
 
     # Valid XML strings can include any Unicode character, excluding control
-    # characters, the surrogate blocks, FFFE, and FFFF.
-    # Char ::= #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF]
-    # This is the inverted regular expression matchin any invalid character
-    _invalid_xml_string = re.compile(
-        "[\u0000-\u0008\u000B-\u000C\u000E-\u001F\uD800-\uDFFF\uFFFE-\uFFFF]"
-    )
+    # characters, the surrogate blocks, FFFE, and FFFF:
+    #   Char ::= #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF]
+    # Here we reversed the pattern to match only the invalid characters.
+    # For the 'narrow' python builds supporting only UCS-2, which represent
+    # characters beyond BMP as UTF-16 surrogate pairs, we need to pass through
+    # the surrogate block. I haven't found a more elegant solution...
+    UCS2 = sys.maxunicode < 0x10FFFF
+    if UCS2:
+        _invalid_xml_string = re.compile(
+            "[\u0000-\u0008\u000B-\u000C\u000E-\u001F\uFFFE-\uFFFF]"
+        )
+    else:
+        _invalid_xml_string = re.compile(
+            "[\u0000-\u0008\u000B-\u000C\u000E-\u001F\uD800-\uDFFF\uFFFE-\uFFFF]"
+        )
 
     def _tounicode(s):
         """Test if a string is valid user input and decode it to unicode string

--- a/Lib/ufoLib/etree.py
+++ b/Lib/ufoLib/etree.py
@@ -48,7 +48,6 @@ try:
     from lxml.etree import *
 
     _have_lxml = True
-    _dict_is_ordered = True
 except ImportError:
     try:
         from xml.etree.cElementTree import *
@@ -56,7 +55,7 @@ except ImportError:
         # the cElementTree version of XML function doesn't support
         # the optional 'parser' keyword argument
         from xml.etree.ElementTree import XML
-    except ImportError:
+    except ImportError:  # pragma: no cover
         from xml.etree.ElementTree import *
     _have_lxml = False
 
@@ -143,7 +142,7 @@ except ImportError:
             xml_declaration=False,
             method=None,
             doctype=None,
-            pretty_print=True,
+            pretty_print=False,
         ):
             if method and method != "xml":
                 # delegate to super-class
@@ -203,7 +202,7 @@ except ImportError:
         xml_declaration=None,
         method=None,
         doctype=None,
-        pretty_print=True,
+        pretty_print=False,
     ):
         """Custom 'tostring' function that uses our ElementTree subclass, with
         pretty_print support.

--- a/Lib/ufoLib/etree.py
+++ b/Lib/ufoLib/etree.py
@@ -225,9 +225,18 @@ except ImportError:
 
     # any Unicode character, excluding the surrogate blocks, FFFE, and FFFF.
     # Char ::= #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF]
-    _valid_xml_string = re.compile(
-        "^[\u0009\u000a\u000d\u0020-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]+$"
-    )
+    UCS2 = sys.maxunicode < 0x10FFFF
+    if UCS2:
+        # For 'narrow' python builds we need to match the UTF-16 surrogate pairs
+        # for the characters beyond the BMP (0x10000..0x10FFFF).
+        _valid_xml_string = re.compile(
+            "^(?:[\u0009\u000a\u000d\u0020-\uD7FF\uE000-\uFFFD]|"
+            "(?:[\uD800-\uDBFF][\uDC00-\uDFFF]))+$"
+        )
+    else:
+        _valid_xml_string = re.compile(
+            "^[\u0009\u000a\u000d\u0020-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]+$"
+        )
 
     def _tounicode(s):
         """Test if a string is valid user input and decode it to unicode string

--- a/Lib/ufoLib/etree.py
+++ b/Lib/ufoLib/etree.py
@@ -1,0 +1,471 @@
+"""Shim module exporting the same ElementTree API for lxml and
+xml.etree backends.
+
+When lxml is installed, it is automatically preferred over the built-in
+xml.etree module.
+On Python 2.7, the cElementTree module is preferred over the pure-python
+ElementTree module.
+
+Besides exporting a unified interface, this also defines extra functions
+or subclasses built-in ElementTree classes to add features that are
+only availble in lxml, like OrderedDict for attributes, pretty_print and
+iterwalk.
+"""
+from __future__ import absolute_import, unicode_literals
+from fontTools.misc.py23 import basestring, unicode, tounicode, open
+
+# we use a custom XML declaration for backward compatibility with older
+# ufoLib versions which would write it using double quotes.
+# https://github.com/unified-font-object/ufoLib/issues/158
+XML_DECLARATION = """<?xml version="1.0" encoding="%s"?>"""
+
+__all__ = [
+    # public symbols
+    "Comment",
+    "dump",
+    "Element",
+    "ElementTree",
+    "fromstring",
+    "fromstringlist",
+    "iselement",
+    "iterparse",
+    "parse",
+    "ParseError",
+    "PI",
+    "ProcessingInstruction",
+    "QName",
+    "SubElement",
+    "tostring",
+    "tostringlist",
+    "TreeBuilder",
+    "XML",
+    "XMLParser",
+    "XMLTreeBuilder",
+    "register_namespace",
+]
+
+try:
+    from lxml.etree import *
+
+    _have_lxml = True
+    _dict_is_ordered = True
+except ImportError:
+    try:
+        from xml.etree.cElementTree import *
+
+        # the cElementTree version of XML function doesn't support
+        # the optional 'parser' keyword argument
+        from xml.etree.ElementTree import XML
+    except ImportError:
+        from xml.etree.ElementTree import *
+    _have_lxml = False
+
+    import sys
+
+    # dict is always ordered in python >= 3.6 and on pypy
+    PY36 = sys.version_info >= (3, 6)
+    try:
+        import __pypy__
+    except ImportError:
+        __pypy__ = None
+    _dict_is_ordered = bool(PY36 or __pypy__)
+    del PY36, __pypy__
+
+    if _dict_is_ordered:
+        _Attrib = dict
+    else:
+        from collections import OrderedDict as _Attrib
+
+    if isinstance(Element, type):
+        _Element = Element
+    else:
+        # in py27, cElementTree.Element cannot be subclassed, so
+        # we need to import the pure-python class
+        from xml.etree.ElementTree import Element as _Element
+
+    class Element(_Element):
+        """Element subclass that keeps the order of attributes."""
+
+        def __init__(self, tag, attrib=_Attrib(), **extra):
+            super(Element, self).__init__(tag)
+            self.attrib = _Attrib()
+            if attrib:
+                self.attrib.update(attrib)
+            if extra:
+                self.attrib.update(extra)
+
+    def SubElement(parent, tag, attrib=_Attrib(), **extra):
+        """Must override SubElement as well otherwise _elementtree.SubElement
+        fails if 'parent' is a subclass of Element object.
+        """
+        element = parent.__class__(tag, attrib, **extra)
+        parent.append(element)
+        return element
+
+    def _iterwalk(element, events, tag):
+        include = tag is None or element.tag == tag
+        if include and "start" in events:
+            yield ("start", element)
+        for e in element:
+            for item in _iterwalk(e, events, tag):
+                yield item
+        if include:
+            yield ("end", element)
+
+    def iterwalk(element_or_tree, events=("end",), tag=None):
+        """A tree walker that generates events from an existing tree as
+        if it was parsing XML data with iterparse().
+        Drop-in replacement for lxml.etree.iterwalk.
+        """
+        if iselement(element_or_tree):
+            element = element_or_tree
+        else:
+            element = element_or_tree.getroot()
+        if tag == "*":
+            tag = None
+        for item in _iterwalk(element, events, tag):
+            yield item
+
+    _ElementTree = ElementTree
+
+    class ElementTree(_ElementTree):
+        """ElementTree subclass that adds 'pretty_print' and 'doctype'
+        arguments to the 'write' method.
+        Currently these are only supported for the default XML serialization
+        'method', and not also for "html" or "text", for these are delegated
+        to the base class.
+        """
+
+        def write(
+            self,
+            file_or_filename,
+            encoding=None,
+            xml_declaration=False,
+            method=None,
+            doctype=None,
+            pretty_print=True,
+        ):
+            if method and method != "xml":
+                # delegate to super-class
+                super(ElementTree, self).write(
+                    file_or_filename,
+                    encoding=encoding,
+                    xml_declaration=xml_declaration,
+                    method=method,
+                )
+                return
+
+            if encoding is unicode or (
+                encoding is not None and encoding.lower() == "unicode"
+            ):
+                if xml_declaration:
+                    raise ValueError(
+                        "Serialisation to unicode must not request an XML declaration"
+                    )
+                write_declaration = False
+                encoding = "unicode"
+            elif xml_declaration is None:
+                # by default, write an XML declaration only for non-standard encodings
+                write_declaration = encoding is not None and encoding.upper() not in (
+                    "ASCII",
+                    "UTF-8",
+                    "UTF8",
+                    "US-ASCII",
+                )
+            else:
+                write_declaration = xml_declaration
+
+            if encoding is None:
+                encoding = "ASCII"
+
+            if pretty_print:
+                # NOTE this will modify the tree in-place
+                _indent(self._root)
+
+            with _get_writer(file_or_filename, encoding) as write:
+                if write_declaration:
+                    write(XML_DECLARATION % encoding.upper())
+                    if pretty_print:
+                        write("\n")
+                if doctype:
+                    write(_tounicode(doctype))
+                    if pretty_print:
+                        write("\n")
+
+                qnames, namespaces = _namespaces(self._root)
+                _serialize_xml(write, self._root, qnames, namespaces)
+
+    import io
+
+    def tostring(
+        element,
+        encoding=None,
+        xml_declaration=None,
+        method=None,
+        doctype=None,
+        pretty_print=True,
+    ):
+        """Custom 'tostring' function that uses our ElementTree subclass, with
+        pretty_print support.
+        """
+        stream = io.StringIO() if encoding == "unicode" else io.BytesIO()
+        ElementTree(element).write(
+            stream,
+            encoding=encoding,
+            xml_declaration=xml_declaration,
+            method=method,
+            doctype=doctype,
+            pretty_print=pretty_print,
+        )
+        return stream.getvalue()
+
+    # serialization support
+
+    import re
+
+    # any Unicode character, excluding the surrogate blocks, FFFE, and FFFF.
+    # Char ::= #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF]
+    _valid_xml_string = re.compile(
+        "^[\u0009\u000a\u000d\u0020-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]+$"
+    )
+
+    def _tounicode(s):
+        """Test if a string is valid user input and decode it to unicode string
+        using ASCII encoding if it's a bytes string.
+        Reject all bytes/unicode input that contains non-XML characters.
+        Reject all bytes input that contains non-ASCII characters.
+        """
+        try:
+            s = tounicode(s)
+        except AttributeError:
+            _raise_serialization_error(s)
+        if s and not _valid_xml_string.match(s):
+            raise ValueError(
+                "All strings must be XML compatible: Unicode or ASCII, "
+                "no NULL bytes or control characters"
+            )
+        return s
+
+    import contextlib
+
+    @contextlib.contextmanager
+    def _get_writer(file_or_filename, encoding):
+        # returns text write method and release all resources after using
+        try:
+            write = file_or_filename.write
+        except AttributeError:
+            # file_or_filename is a file name
+            f = open(
+                file_or_filename,
+                "w",
+                encoding="utf-8" if encoding == "unicode" else encoding,
+                errors="xmlcharrefreplace",
+            )
+            with f:
+                yield f.write
+        else:
+            # file_or_filename is a file-like object
+            # encoding determines if it is a text or binary writer
+            if encoding == "unicode":
+                # use a text writer as is
+                yield write
+            else:
+                # wrap a binary writer with TextIOWrapper
+                detach_buffer = False
+                if isinstance(file_or_filename, io.BufferedIOBase):
+                    buf = file_or_filename
+                elif isinstance(file_or_filename, io.RawIOBase):
+                    buf = io.BufferedWriter(file_or_filename)
+                    detach_buffer = True
+                else:
+                    # This is to handle passed objects that aren't in the
+                    # IOBase hierarchy, but just have a write method
+                    buf = io.BufferedIOBase()
+                    buf.writable = lambda: True
+                    buf.write = write
+                    try:
+                        # TextIOWrapper uses this methods to determine
+                        # if BOM (for UTF-16, etc) should be added
+                        buf.seekable = file_or_filename.seekable
+                        buf.tell = file_or_filename.tell
+                    except AttributeError:
+                        pass
+                wrapper = io.TextIOWrapper(
+                    buf,
+                    encoding=encoding,
+                    errors="xmlcharrefreplace",
+                    newline="\n",
+                )
+                try:
+                    yield wrapper.write
+                finally:
+                    # Keep the original file open when the TextIOWrapper and
+                    # the BufferedWriter are destroyed
+                    wrapper.detach()
+                    if detach_buffer:
+                        buf.detach()
+
+    from xml.etree.ElementTree import _namespace_map
+
+    def _namespaces(elem):
+        # identify namespaces used in this tree
+
+        # maps qnames to *encoded* prefix:local names
+        qnames = {None: None}
+
+        # maps uri:s to prefixes
+        namespaces = {}
+
+        def add_qname(qname):
+            # calculate serialized qname representation
+            try:
+                qname = _tounicode(qname)
+                if qname[:1] == "{":
+                    uri, tag = qname[1:].rsplit("}", 1)
+                    prefix = namespaces.get(uri)
+                    if prefix is None:
+                        prefix = _namespace_map.get(uri)
+                        if prefix is None:
+                            prefix = "ns%d" % len(namespaces)
+                        else:
+                            prefix = _tounicode(prefix)
+                        if prefix != "xml":
+                            namespaces[uri] = prefix
+                    if prefix:
+                        qnames[qname] = "%s:%s" % (prefix, tag)
+                    else:
+                        qnames[qname] = tag  # default element
+                else:
+                    qnames[qname] = qname
+            except TypeError:
+                _raise_serialization_error(qname)
+
+        # populate qname and namespaces table
+        for elem in elem.iter():
+            tag = elem.tag
+            if isinstance(tag, QName):
+                if tag.text not in qnames:
+                    add_qname(tag.text)
+            elif isinstance(tag, basestring):
+                if tag not in qnames:
+                    add_qname(tag)
+            elif tag is not None and tag is not Comment and tag is not PI:
+                _raise_serialization_error(tag)
+            for key, value in elem.items():
+                if isinstance(key, QName):
+                    key = key.text
+                if key not in qnames:
+                    add_qname(key)
+                if isinstance(value, QName) and value.text not in qnames:
+                    add_qname(value.text)
+            text = elem.text
+            if isinstance(text, QName) and text.text not in qnames:
+                add_qname(text.text)
+        return qnames, namespaces
+
+    def _serialize_xml(write, elem, qnames, namespaces, **kwargs):
+        tag = elem.tag
+        text = elem.text
+        if tag is Comment:
+            write("<!--%s-->" % _tounicode(text))
+        elif tag is ProcessingInstruction:
+            write("<?%s?>" % _tounicode(text))
+        else:
+            tag = qnames[_tounicode(tag) if tag is not None else None]
+            if tag is None:
+                if text:
+                    write(_escape_cdata(text))
+                for e in elem:
+                    _serialize_xml(write, e, qnames, None)
+            else:
+                write("<" + tag)
+                if namespaces:
+                    for uri, prefix in sorted(
+                        namespaces.items(), key=lambda x: x[1]
+                    ):  # sort on prefix
+                        if prefix:
+                            prefix = ":" + prefix
+                        write(' xmlns%s="%s"' % (prefix, _escape_attrib(uri)))
+                attrs = elem.attrib
+                if attrs:
+                    # try to keep existing attrib order
+                    if len(attrs) <= 1 or type(attrs) is _Attrib:
+                        items = attrs.items()
+                    else:
+                        # if plain dict, use lexical order
+                        items = sorted(attrs.items())
+                    for k, v in items:
+                        if isinstance(k, QName):
+                            k = _tounicode(k.text)
+                        else:
+                            k = _tounicode(k)
+                        if isinstance(v, QName):
+                            v = qnames[_tounicode(v.text)]
+                        else:
+                            v = _escape_attrib(v)
+                        write(' %s="%s"' % (qnames[k], v))
+                if text or len(elem):
+                    write(">")
+                    if text:
+                        write(_escape_cdata(text))
+                    for e in elem:
+                        _serialize_xml(write, e, qnames, None)
+                    write("</" + tag + ">")
+                else:
+                    write("/>")
+        if elem.tail:
+            write(_escape_cdata(elem.tail))
+
+    def _raise_serialization_error(text):
+        raise TypeError(
+            "cannot serialize %r (type %s)" % (text, type(text).__name__)
+        )
+
+    def _escape_cdata(text):
+        # escape character data
+        try:
+            text = _tounicode(text)
+            # it's worth avoiding do-nothing calls for short strings
+            if "&" in text:
+                text = text.replace("&", "&amp;")
+            if "<" in text:
+                text = text.replace("<", "&lt;")
+            if ">" in text:
+                text = text.replace(">", "&gt;")
+            return text
+        except (TypeError, AttributeError):
+            _raise_serialization_error(text)
+
+    def _escape_attrib(text):
+        # escape attribute value
+        try:
+            text = _tounicode(text)
+            if "&" in text:
+                text = text.replace("&", "&amp;")
+            if "<" in text:
+                text = text.replace("<", "&lt;")
+            if ">" in text:
+                text = text.replace(">", "&gt;")
+            if '"' in text:
+                text = text.replace('"', "&quot;")
+            if "\n" in text:
+                text = text.replace("\n", "&#10;")
+            return text
+        except (TypeError, AttributeError):
+            _raise_serialization_error(text)
+
+    def _indent(elem, level=0):
+        # From http://effbot.org/zone/element-lib.htm#prettyprint
+        i = "\n" + level * "  "
+        if len(elem):
+            if not elem.text or not elem.text.strip():
+                elem.text = i + "  "
+            if not elem.tail or not elem.tail.strip():
+                elem.tail = i
+            for elem in elem:
+                _indent(elem, level + 1)
+            if not elem.tail or not elem.tail.strip():
+                elem.tail = i
+        else:
+            if level and (not elem.tail or not elem.tail.strip()):
+                elem.tail = i

--- a/Lib/ufoLib/etree.py
+++ b/Lib/ufoLib/etree.py
@@ -247,7 +247,11 @@ except ImportError:
         Reject all bytes input that contains non-ASCII characters.
         """
         try:
-            s = tounicode(s)
+            s = tounicode(s, encoding="ascii", errors="strict")
+        except UnicodeDecodeError:
+            raise ValueError(
+                "Bytes strings can only contain ASCII characters. "
+                "Use unicode strings for non-ASCII characters.")
         except AttributeError:
             _raise_serialization_error(s)
         if s and _invalid_xml_string.search(s):

--- a/Lib/ufoLib/etree.py
+++ b/Lib/ufoLib/etree.py
@@ -415,7 +415,7 @@ except ImportError:
                         else:
                             v = _escape_attrib(v)
                         write(' %s="%s"' % (qnames[k], v))
-                if text or len(elem):
+                if text is not None or len(elem):
                     write(">")
                     if text:
                         write(_escape_cdata(text))

--- a/Lib/ufoLib/filenames.py
+++ b/Lib/ufoLib/filenames.py
@@ -2,7 +2,7 @@
 User name to file name conversion.
 This was taken form the UFO 3 spec.
 """
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 from fontTools.misc.py23 import basestring, unicode
 
 

--- a/Lib/ufoLib/glifLib.py
+++ b/Lib/ufoLib/glifLib.py
@@ -11,7 +11,7 @@ in a folder. It offers two ways to read glyph data, and one way to write
 glyph data. See the class doc string for details.
 """
 
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 import os
 from io import BytesIO, open
 from warnings import warn

--- a/Lib/ufoLib/glifLib.py
+++ b/Lib/ufoLib/glifLib.py
@@ -22,8 +22,8 @@ from ufoLib.pointPen import AbstractPointPen, PointToSegmentPen
 from ufoLib.filenames import userNameToFileName
 from ufoLib.validators import isDictEnough, genericTypeValidator, colorValidator,\
 	guidelinesValidator, anchorsValidator, identifierValidator, imageValidator, glyphLibValidator
+from ufoLib import etree
 
-from lxml import etree
 
 __all__ = [
 	"GlyphSet",

--- a/Lib/ufoLib/kerning.py
+++ b/Lib/ufoLib/kerning.py
@@ -1,3 +1,6 @@
+from __future__ import absolute_import, unicode_literals
+
+
 def lookupKerningValue(pair, kerning, groups, fallback=0, glyphToFirstGroup=None, glyphToSecondGroup=None):
 	"""
 	Note: This expects kerning to be a flat dictionary

--- a/Lib/ufoLib/pointPen.py
+++ b/Lib/ufoLib/pointPen.py
@@ -11,6 +11,7 @@ steps through all the points in a call from glyph.drawPoints().
 This allows the caller to provide more data for each point.
 For instance, whether or not a point is smooth, and its name.
 """
+from __future__ import absolute_import, unicode_literals
 from fontTools.pens.basePen import AbstractPen
 import math
 

--- a/Lib/ufoLib/test/testSupport.py
+++ b/Lib/ufoLib/test/testSupport.py
@@ -1,6 +1,6 @@
 """Miscellaneous helpers for our test suite."""
 
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 import sys
 import os
 import unittest

--- a/Lib/ufoLib/test/test_GLIF1.py
+++ b/Lib/ufoLib/test/test_GLIF1.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 import unittest
 from ufoLib.glifLib import GlifLibError, readGlyphFromString, writeGlyphToString
 from ufoLib.test.testSupport import Glyph, stripText

--- a/Lib/ufoLib/test/test_GLIF2.py
+++ b/Lib/ufoLib/test/test_GLIF2.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 import unittest
 from ufoLib.glifLib import GlifLibError, readGlyphFromString, writeGlyphToString
 from ufoLib.test.testSupport import Glyph, stripText

--- a/Lib/ufoLib/test/test_UFO1.py
+++ b/Lib/ufoLib/test/test_UFO1.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import, unicode_literals
 import os
 import shutil
 import unittest

--- a/Lib/ufoLib/test/test_UFO2.py
+++ b/Lib/ufoLib/test/test_UFO2.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import, unicode_literals
 import os
 import shutil
 import unittest

--- a/Lib/ufoLib/test/test_UFO3.py
+++ b/Lib/ufoLib/test/test_UFO3.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 import os
 import shutil
 import unittest

--- a/Lib/ufoLib/test/test_UFO3.py
+++ b/Lib/ufoLib/test/test_UFO3.py
@@ -5,6 +5,7 @@ import shutil
 import unittest
 import tempfile
 from io import open
+from fontTools.misc.py23 import unicode
 from ufoLib import UFOReader, UFOWriter, UFOLibError
 from ufoLib.glifLib import GlifLibError
 from ufoLib import plistlib
@@ -4130,6 +4131,28 @@ class UFO3WriteLayersTestCase(unittest.TestCase):
 		writer = UFOWriter(self.ufoPath)
 		self.assertRaises(UFOLibError, writer.deleteGlyphSet, "does not exist")
 
+	def testWriteAsciiLayerOrder(self):
+		self.makeUFO(
+			layerContents=[
+				["public.default", "glyphs"],
+				["layer 1", "glyphs.layer 1"],
+				["layer 2", "glyphs.layer 2"],
+			]
+		)
+		writer = UFOWriter(self.ufoPath)
+		# if passed bytes string, it'll be decoded to ASCII unicode string
+		writer.writeLayerContents(["public.default", "layer 2", b"layer 1"])
+		path = os.path.join(self.ufoPath, "layercontents.plist")
+		with open(path, "rb") as f:
+			result = plistlib.load(f)
+		expected = [
+			["public.default", "glyphs"],
+			["layer 2", "glyphs.layer 2"],
+			["layer 1", "glyphs.layer 1"],
+		]
+		self.assertEqual(expected, result)
+		for layerName, directory in result:
+			assert isinstance(layerName, unicode)
 
 # -----
 # /data

--- a/Lib/ufoLib/test/test_UFOConversion.py
+++ b/Lib/ufoLib/test/test_UFOConversion.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import, unicode_literals
 import os
 import shutil
 import unittest

--- a/Lib/ufoLib/test/test_etree.py
+++ b/Lib/ufoLib/test/test_etree.py
@@ -1,0 +1,40 @@
+# coding: utf-8
+from __future__ import absolute_import, unicode_literals
+from ufoLib import etree
+import io
+import pytest
+
+
+@pytest.mark.parametrize(
+    "xml",
+    [
+        (
+            "<root>"
+            '<element key="value">text</element>'
+            "<element>text</element>tail"
+            "<empty-element/>"
+            "</root>"
+        ),
+        (
+            "<root>\n"
+            '  <element key="value">text</element>\n'
+            "  <element>text</element>tail\n"
+            "  <empty-element/>\n"
+            "</root>"
+        ),
+        (
+            '<axis default="400" maximum="1000" minimum="1" name="weight" tag="wght">'
+            '<labelname xml:lang="fa-IR">قطر</labelname>'
+            '</axis>'
+        )
+    ],
+    ids=[
+        "simple_xml_no_indent",
+        "simple_xml_indent",
+        "xml_ns_attrib_utf_8",
+    ]
+)
+def test_roundtrip_string(xml):
+    root = etree.fromstring(xml.encode("utf-8"))
+    result = etree.tostring(root, encoding="utf-8").decode("utf-8")
+    assert result == xml

--- a/Lib/ufoLib/test/test_etree.py
+++ b/Lib/ufoLib/test/test_etree.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 from __future__ import absolute_import, unicode_literals
 from ufoLib import etree
+from collections import OrderedDict
 import io
 import pytest
 
@@ -25,16 +26,30 @@ import pytest
         (
             '<axis default="400" maximum="1000" minimum="1" name="weight" tag="wght">'
             '<labelname xml:lang="fa-IR">قطر</labelname>'
-            '</axis>'
-        )
+            "</axis>"
+        ),
     ],
-    ids=[
-        "simple_xml_no_indent",
-        "simple_xml_indent",
-        "xml_ns_attrib_utf_8",
-    ]
+    ids=["simple_xml_no_indent", "simple_xml_indent", "xml_ns_attrib_utf_8"],
 )
 def test_roundtrip_string(xml):
     root = etree.fromstring(xml.encode("utf-8"))
     result = etree.tostring(root, encoding="utf-8").decode("utf-8")
     assert result == xml
+
+
+def test_pretty_print():
+    root = etree.Element("root")
+    attrs = OrderedDict([("c", "2"), ("b", "1"), ("a", "0")])
+    etree.SubElement(root, "element", attrs).text = "text"
+    etree.SubElement(root, "element").text = "text"
+    root.append(etree.Element("empty-element"))
+
+    result = etree.tostring(root, encoding="unicode", pretty_print=True)
+
+    assert result == (
+        "<root>\n"
+        '  <element c="2" b="1" a="0">text</element>\n'
+        "  <element>text</element>\n"
+        "  <empty-element/>\n"
+        "</root>\n"
+    )

--- a/Lib/ufoLib/test/test_filenames.py
+++ b/Lib/ufoLib/test/test_filenames.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 import unittest
 from ufoLib.filenames import userNameToFileName, handleClash1, handleClash2
 

--- a/Lib/ufoLib/test/test_glifLib.py
+++ b/Lib/ufoLib/test/test_glifLib.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, unicode_literals
 import os
 import tempfile
 import shutil

--- a/Lib/ufoLib/test/test_plistlib.py
+++ b/Lib/ufoLib/test/test_plistlib.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import, unicode_literals
-from ufoLib import plistlib
+import sys
 import os
 import datetime
 import codecs
@@ -8,7 +8,18 @@ from io import BytesIO
 from numbers import Integral
 from fontTools.misc.py23 import tounicode
 from ufoLib import etree
+from ufoLib import plistlib
 import pytest
+
+
+PY2 = sys.version_info < (3,)
+if PY2:
+    # This is a ResourceWarning that only happens on py27 at interpreter
+    # finalization, and only when coverage is enabled. We can ignore it.
+    # https://github.com/numpy/numpy/issues/3778#issuecomment-24885336
+    pytestmark = pytest.mark.filterwarnings(
+        "ignore:tp_compare didn't return -1 or -2 for exception"
+    )
 
 
 # The testdata is generated using https://github.com/python/cpython/...
@@ -382,9 +393,9 @@ def test_totree(pl):
 def test_no_pretty_print():
     data = plistlib.dumps({"data": b"hello"}, pretty_print=False)
     assert data == (
-        plistlib.XML_DECLARATION +
-        plistlib.PLIST_DOCTYPE +
-        b'<plist version="1.0">'
+        plistlib.XML_DECLARATION
+        + plistlib.PLIST_DOCTYPE
+        + b'<plist version="1.0">'
         b"<dict>"
         b"<key>data</key>"
         b"<data>aGVsbG8=</data>"

--- a/Lib/ufoLib/utils.py
+++ b/Lib/ufoLib/utils.py
@@ -1,6 +1,7 @@
 """The module contains miscellaneous helpers.
 It's not considered part of the public ufoLib API.
 """
+from __future__ import absolute_import, unicode_literals
 import warnings
 import functools
 

--- a/Lib/ufoLib/validators.py
+++ b/Lib/ufoLib/validators.py
@@ -1,5 +1,6 @@
 """Various low level data validators."""
 
+from __future__ import absolute_import, unicode_literals
 import os
 import calendar
 from io import open

--- a/Lib/ufoLib/validators.py
+++ b/Lib/ufoLib/validators.py
@@ -952,21 +952,26 @@ def fontLibValidator(value):
 	>>> fontLibValidator(lib)
 	(True, None)
 
-	>>> lib = {"public.glyphOrder" : [u"A", u"C", u"B"]}
-	>>> fontLibValidator(lib)
-	(True, None)
-
 	>>> lib = "hello"
-	>>> fontLibValidator(lib)
-	(False, 'The lib data is not in the correct format: expected a dictionary, found str')
+	>>> valid, msg = fontLibValidator(lib)
+	>>> valid
+	False
+	>>> print(msg)  # doctest: +ELLIPSIS
+	The lib data is not in the correct format: expected a dictionary, ...
 
 	>>> lib = {1: "hello"}
-	>>> fontLibValidator(lib)
-	(False, 'The lib key is not properly formatted: expected basestring, found int: 1')
+	>>> valid, msg = fontLibValidator(lib)
+	>>> valid
+	False
+	>>> print(msg)
+	The lib key is not properly formatted: expected basestring, found int: 1
 
 	>>> lib = {"public.glyphOrder" : "hello"}
-	>>> fontLibValidator(lib)
-	(False, 'public.glyphOrder is not properly formatted: expected list or tuple, found str')
+	>>> valid, msg = fontLibValidator(lib)
+	>>> valid
+	False
+	>>> print(msg)  # doctest: +ELLIPSIS
+	public.glyphOrder is not properly formatted: expected list or tuple,...
 
 	>>> lib = {"public.glyphOrder" : ["A", 1, "B"]}
 	>>> fontLibValidator(lib)

--- a/README.md
+++ b/README.md
@@ -10,6 +10,18 @@ A low-level [UFO] reader and writer.
 
 [UFO] is a human-readable, XML-based file format that stores font source files.
 
+### Installation
+
+```sh
+$ pip install ufoLib
+```
+
+For better speed, you can install with extra dependencies like this:
+
+```sh
+$ pip install ufoLib[lxml]
+```
+
 [UFO]: http://unifiedfontobject.org/
 
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,38 +4,22 @@ environment:
     - PYTHON: "C:\\Python27"
       PYTHON_VERSION: "2.7.x"
       PYTHON_ARCH: "32"
-      TOXENV: "py27"
+      TOXENV: "py27-cov,py27-cov-lxml"
       TOXPYTHON: "C:\\Python27\\python.exe"
-
-    - PYTHON: "C:\\Python35"
-      PYTHON_VERSION: "3.5.x"
-      PYTHON_ARCH: "32"
-      TOXENV: "py35"
-      TOXPYTHON: "C:\\Python35\\python.exe"
-
-    - PYTHON: "C:\\Python36"
-      PYTHON_VERSION: "3.6.x"
-      PYTHON_ARCH: "32"
-      TOXENV: "py36"
-      TOXPYTHON: "C:\\Python36\\python.exe"
-
-    - PYTHON: "C:\\Python27-x64"
-      PYTHON_VERSION: "2.7.x"
-      PYTHON_ARCH: "64"
-      TOXENV: "py27"
-      TOXPYTHON: "C:\\Python27-x64\\python.exe"
-
-    - PYTHON: "C:\\Python35-x64"
-      PYTHON_VERSION: "3.5.x"
-      PYTHON_ARCH: "64"
-      TOXENV: "py35"
-      TOXPYTHON: "C:\\Python35-x64\\python.exe"
 
     - PYTHON: "C:\\Python36-x64"
       PYTHON_VERSION: "3.6.x"
       PYTHON_ARCH: "64"
-      TOXENV: "py36"
+      TOXENV: "py36-cov,py36-cov-lxml"
       TOXPYTHON: "C:\\Python36-x64\\python.exe"
+
+    - PYTHON: "C:\\Python37-x64"
+      PYTHON_VERSION: "3.7.x"
+      PYTHON_ARCH: "64"
+      TOXENV: "py37-cov,py37-cov-lxml"
+      TOXPYTHON: "C:\\Python37-x64\\python.exe"
+
+skip_branch_with_pr: true
 
 init:
   - "ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH%"
@@ -65,3 +49,7 @@ build: false
 
 test_script:
   - "tox"
+
+on_success:
+  # upload test coverage to codecov.io
+  - tox -e codecov

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,9 @@ environment:
     - PYTHON: "C:\\Python37-x64"
       PYTHON_VERSION: "3.7.x"
       PYTHON_ARCH: "64"
-      TOXENV: "py37-cov,py37-cov-lxml"
+      # lxml doesn't have windows 3.7 wheels yet
+      # TOXENV: "py37-cov,py37-cov-lxml"
+      TOXENV: "py37-cov"
       TOXPYTHON: "C:\\Python37-x64\\python.exe"
 
 skip_branch_with_pr: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,6 +23,9 @@ environment:
 
 skip_branch_with_pr: true
 
+matrix:
+  fast_finish: true
+
 init:
   - "ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH%"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,13 +5,11 @@ environment:
       PYTHON_VERSION: "2.7.x"
       PYTHON_ARCH: "32"
       TOXENV: "py27-cov,py27-cov-lxml"
-      TOXPYTHON: "C:\\Python27\\python.exe"
 
     - PYTHON: "C:\\Python36-x64"
       PYTHON_VERSION: "3.6.x"
       PYTHON_ARCH: "64"
       TOXENV: "py36-cov,py36-cov-lxml"
-      TOXPYTHON: "C:\\Python36-x64\\python.exe"
 
     - PYTHON: "C:\\Python37-x64"
       PYTHON_VERSION: "3.7.x"
@@ -19,7 +17,6 @@ environment:
       # lxml doesn't have windows 3.7 wheels yet
       # TOXENV: "py37-cov,py37-cov-lxml"
       TOXENV: "py37-cov"
-      TOXPYTHON: "C:\\Python37-x64\\python.exe"
 
 skip_branch_with_pr: true
 
@@ -49,6 +46,12 @@ install:
 
   # install tox to run test suite in a virtual environment
   - "pip install -U tox"
+
+  # Make a python3.7.bat file in the current directory so that tox will find it
+  # and python3.7 will mean what we want it to. E.g. for TOXENV=py27, this will
+  # save a python2.7.bat file containing "@C:\Python27\python %*"
+  # Credit: https://nedbatchelder.com/blog/201509/appveyor.html
+  - "python -c \"import os; open('python{0}.{1}.bat'.format(*os.environ['TOXENV'][2:]), 'w').write('@{0}\\\\python \\x25*\\n'.format(os.environ['PYTHON']))\""
 
 build: false
 

--- a/extra_requirements.txt
+++ b/extra_requirements.txt
@@ -1,0 +1,2 @@
+lxml==4.2.3
+singledispatch==3.4.0.3; python_version < '3.4'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,1 @@
 fonttools==3.28.0
-lxml==4.2.3
-singledispatch==3.4.0.3; python_version < '3.4'

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,6 @@ minversion = 3.0.2
 testpaths = 
 	ufoLib
 addopts = 
-	-v
 	-r a
 	--doctest-modules
 	--doctest-ignore-import-errors

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,7 @@ license_file = LICENSE.txt
 minversion = 3.0.2
 testpaths = 
 	ufoLib
+doctest_optionflags = ALLOW_UNICODE ALLOW_BYTES
 addopts = 
 	-r a
 	--doctest-modules

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,9 +39,11 @@ license_file = LICENSE.txt
 [tool:pytest]
 minversion = 3.0.2
 testpaths = 
-	Lib/ufoLib
+	ufoLib
 addopts = 
 	-v
 	-r a
 	--doctest-modules
+	--doctest-ignore-import-errors
+	--pyargs
 

--- a/setup.py
+++ b/setup.py
@@ -166,9 +166,13 @@ setup_params = dict(
 	],
 	install_requires=[
 		"fonttools >= 3.1.2, < 4",
-		"lxml >= 4.0, < 5",
-		"singledispatch >= 3.4.0.3, < 4; python_version < '3.4'",
 	],
+	extras_require={
+		"lxml": [
+			"lxml >= 4.0, < 5",
+			"singledispatch >= 3.4.0.3, < 4; python_version < '3.4'",
+		],
+	},
 	cmdclass={
 		"release": release,
 		"bump_version": bump_version,

--- a/setup.py
+++ b/setup.py
@@ -172,6 +172,11 @@ setup_params = dict(
 			"lxml >= 4.0, < 5",
 			"singledispatch >= 3.4.0.3, < 4; python_version < '3.4'",
 		],
+		"testing": [
+			"pytest >= 3.0.0, <4",
+			"pytest-cov >= 2.5.1, <3",
+			"pytest-randomly >= 1.2.3, <2",
+		],
 	},
 	cmdclass={
 		"release": release,

--- a/tox.ini
+++ b/tox.ini
@@ -76,4 +76,4 @@ deps = {[testenv:sdist]deps}
 changedir = {toxinidir}
 commands =
   {[testenv:sdist]commands}
-  pip wheel --no-deps --wheel-dir dist --find-links dist ufoLib
+  pip wheel  -v --no-deps --no-index --no-cache-dir --wheel-dir {toxinidir}/dist --find-links {toxinidir}/dist ufoLib

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,7 @@
 [tox]
-envlist = py27,py36,py{27,36}-lxml
+envlist = py{27,36,37}-cov,py{27,36,37}-cov-lxml,coverage
+minversion = 2.9.1
+skip_missing_interpreters = true
 
 [testenv]
 basepython =
@@ -7,11 +9,71 @@ basepython =
     py27: {env:TOXPYTHON:python2.7}
     py35: {env:TOXPYTHON:python3.5}
     py36: {env:TOXPYTHON:python3.6}
+    py37: {env:TOXPYTHON:python3.7}
+description = run the tests with pytest under {basepython}
+setenv =
+  COVERAGE_FILE={toxinidir}/.coverage.{envname}
 deps =
-    pytest
     -rrequirements.txt
     lxml: -rextra_requirements.txt
+extras = testing
 commands =
-    # run the test suite against the package installed inside tox env.
-    # any extra positional arguments after `tox -- ...` are passed on to pytest
-    pytest {posargs:--pyargs ufoLib}
+  nocov: pytest {posargs}
+  cov: pytest --cov="{envsitepackagesdir}/ufoLib" --cov-config={toxinidir}/.coveragerc {posargs}
+
+[testenv:coverage]
+description = run locally after tests to combine coverage data and create reports;
+              generates a diff coverage against origin/master (or DIFF_AGAINST env var)
+basepython = {env:TOXPYTHON:python}
+deps =
+  coverage >= 4.4.1, < 5
+  diff_cover
+skip_install = true
+setenv =
+  COVERAGE_FILE={toxinidir}/.coverage
+passenv =
+  DIFF_AGAINST
+changedir = {toxinidir}
+commands =
+  coverage erase
+  coverage combine
+  coverage report
+  coverage xml -o {toxworkdir}/coverage.xml
+  coverage html
+  diff-cover --compare-branch {env:DIFF_AGAINST:origin/master} {toxworkdir}/coverage.xml
+
+[testenv:codecov]
+description = upload coverage data to codecov (only run on CI)
+basepython = {env:TOXPYTHON:python}
+deps =
+  {[testenv:coverage]deps}
+  codecov
+skip_install = true
+setenv = {[testenv:coverage]setenv}
+passenv = TOXENV CI TRAVIS TRAVIS_* APPVEYOR APPVEYOR_* CODECOV_*
+changedir = {toxinidir}
+commands =
+  coverage combine
+  codecov --env TOXENV
+
+[testenv:sdist]
+description = build sdist to be uploaded to PyPI
+basepython = {env:TOXPYTHON:python}
+skip_install = true
+deps =
+  setuptools >= 36.4.0
+  wheel >= 0.31.0
+changedir = {toxinidir}
+commands =
+  python -c 'import shutil; shutil.rmtree("dist", ignore_errors=True)'
+  python setup.py sdist --dist-dir dist
+
+[testenv:wheel]
+description = build wheel package for upload to PyPI
+basepython = {env:TOXPYTHON:python}
+skip_install = true
+deps = {[testenv:sdist]deps}
+changedir = {toxinidir}
+commands =
+  {[testenv:sdist]commands}
+  pip wheel --no-deps --wheel-dir dist --find-links dist ufoLib

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py35, py36
+envlist = py27,py36,py{27,36}-lxml
 
 [testenv]
 basepython =
@@ -10,6 +10,7 @@ basepython =
 deps =
     pytest
     -rrequirements.txt
+    lxml: -rextra_requirements.txt
 commands =
     # run the test suite against the package installed inside tox env.
     # any extra positional arguments after `tox -- ...` are passed on to pytest

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,8 @@ deps =
     lxml: -rextra_requirements.txt
 extras = testing
 commands =
+  python --version
+  python -c "import struct; print('%s-bit' % (struct.calcsize('P') * 8))"
   nocov: pytest {posargs}
   cov: pytest --cov="{envsitepackagesdir}/ufoLib" --cov-config={toxinidir}/.coveragerc {posargs}
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,12 +4,6 @@ minversion = 2.9.1
 skip_missing_interpreters = true
 
 [testenv]
-basepython =
-    # we use TOXPYTHON env variable to specify the location of Appveyor Python
-    py27: {env:TOXPYTHON:python2.7}
-    py35: {env:TOXPYTHON:python3.5}
-    py36: {env:TOXPYTHON:python3.6}
-    py37: {env:TOXPYTHON:python3.7}
 description = run the tests with pytest under {basepython}
 setenv =
   COVERAGE_FILE={toxinidir}/.coverage.{envname}
@@ -24,7 +18,6 @@ commands =
 [testenv:coverage]
 description = run locally after tests to combine coverage data and create reports;
               generates a diff coverage against origin/master (or DIFF_AGAINST env var)
-basepython = {env:TOXPYTHON:python}
 deps =
   coverage >= 4.4.1, < 5
   diff_cover
@@ -44,7 +37,6 @@ commands =
 
 [testenv:codecov]
 description = upload coverage data to codecov (only run on CI)
-basepython = {env:TOXPYTHON:python}
 deps =
   {[testenv:coverage]deps}
   codecov
@@ -58,7 +50,6 @@ commands =
 
 [testenv:sdist]
 description = build sdist to be uploaded to PyPI
-basepython = {env:TOXPYTHON:python}
 skip_install = true
 deps =
   setuptools >= 36.4.0
@@ -70,7 +61,6 @@ commands =
 
 [testenv:wheel]
 description = build wheel package for upload to PyPI
-basepython = {env:TOXPYTHON:python}
 skip_install = true
 deps = {[testenv:sdist]deps}
 changedir = {toxinidir}


### PR DESCRIPTION
The reason I haven't tagged ufoLib 3.0 yet is because I was working on allowing to use the built-in `xml.etree` module when lxml is not installed.
The reason is, as much as I love to add third-party dependencies (:grin) and avoid to re-invent the wheel, I believe it makes sense to keep ufoLib working in a simple, pure-python setup, like it was before.
Especially since we are also planning to eventually merge ufoLib into fonttools, where third-party dependencies are even more difficult to add.

this PR adds a `ufoLib.etree` module which exports the same API as the (built-in) `xml.etree.ElementTree` or `lxml.etree`, and uses the latter whenever it is available otherwise falls back on the built-in module. 

In order to produce the same output (with control over the order of the attributes, etc.), I needed to subclass Element and ElementTree objects and basically adapt the serialization part of the built-in ElementTree library.

The current tests pass, which is good. Of course, it is a bit slower than lxml (havent' run benchmarks yet), but the idea is to have it as a reasonable default or fallback, and lxml being the opt-in extra for those who want faster output.

I would like to add some more tests before merging this.