### PR TITLE
adding note in README about move to fontTools.ufoLib

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 ufoLib
 ------
 
+⚠️ **ufoLib moved to [fontTools.ufoLib]** 
+
 A low-level [UFO] reader and writer.
 
 [UFO] is a human-readable, XML-based file format that stores font source files.
@@ -24,3 +26,4 @@ $ pip install ufoLib[lxml]
 ```
 
 [UFO]: http://unifiedfontobject.org/
+[fontTools.ufoLib]: http://github.com/fonttools/fonttools/tree/master/Lib/fontTools/ufoLib


### PR DESCRIPTION
see #181

\+ archive the `unified-font-object/ufoLib` repository (to avoid confusion)
